### PR TITLE
Updated unvaccinated delta script

### DIFF
--- a/analysis/D3updated_inclusion_exclusion_elig_unvaccinated.R
+++ b/analysis/D3updated_inclusion_exclusion_elig_unvaccinated.R
@@ -81,7 +81,7 @@ cohort_flow[nrow(cohort_flow)+1,] <- c(nrow(input),"Inclusion5:Registered in an 
 
 #EXCLUSION CRITERIA 6.SARS-CoV-2 infection recorded prior to the start of follow-up---------------------------------------
 #a.Determine the SARS-CoV-2 infection date
-input$exp_date_covid19_confirmed <- as.Date(input$exp_confirmed_covid19_date)
+input$exp_date_covid19_confirmed <- as.Date(input$exp_date_covid19_confirmed)
 #the earliest date already adopted in the definition
 #b.determine prior to start date infections
 input$prior_infections <- ifelse(input$exp_date_covid19_confirmed < input$unvacc_coh_start_date, 1,0)#1-prior infection; 0 - No prior infection


### PR DESCRIPTION
Hi Genevieve,
I have updated the eligible but unvaccinated delta wave - inclusion/exclusion script, to the study definition version 3.
The main changes are:
1.Under cohort start date: vaccine eligibility date updated, as this variable is directly available now. Hence the previous derivation script for vaccine eligibility date is removed, now.
2.Under cohort end date: The out come variable names updated 
3.Under Exclusion 6:  COVID19 date variable name updated
4.Under Exclusion 7: Vaccination date variable names updated.
I will be happy to reupdate if more changes in variable names come up. 
Many thanks Genevieve!

