### PR TITLE
Add mental health outcomes and corresponding ever covariates

### DIFF
--- a/analysis/codelists.py
+++ b/analysis/codelists.py
@@ -345,17 +345,17 @@ diabetes_drugs_dmd = codelist_from_csv(
     column="dmd_id",
 )
 
-depression_icd10 = codelist_from_csv(
-    "codelists/user-elsie_horne-depression_icd10.csv",
-    system="icd10",
-    column="code",
-)
+# depression_icd10 = codelist_from_csv(
+#     "codelists/user-elsie_horne-depression_icd10.csv",
+#     system="icd10",
+#     column="code",
+# )
 
-depression_snomed_clinical = codelist_from_csv(
-    "codelists/user-elsie_horne-depression_snomed.csv",
-    system="snomed",
-    column="code",
-)
+# depression_snomed_clinical = codelist_from_csv(
+#     "codelists/user-elsie_horne-depression_snomed.csv",
+#     system="snomed",
+#     column="code",
+# )
 
 antiplatelet_dmd = codelist_from_csv(
     "codelists/user-elsie_horne-antiplatelet_dmd.csv",
@@ -741,6 +741,69 @@ preg_primis = codelist_from_csv(
 # Pregnancy or Delivery codes
 pregdel_primis = codelist_from_csv(
     "codelists/primis-covid19-vacc-uptake-pregdel.csv",
+    system="snomed",
+    column="code",
+)
+
+# Depression 
+depression_snomed_clinical = codelist_from_csv(
+    "codelists/user-hjforbes-depression-symptoms-and-diagnoses.csv",
+    system="snomed",
+    column="code",
+)
+
+# Anxiety - general
+anxiety_general_snomed_clinical = codelist_from_csv(
+    "codelists/user-hjforbes-anxiety-symptoms-and-diagnoses.csv",
+    system="snomed",
+    column="code",
+)
+
+# Anxiety - obsessive compulsive disorder
+anxiety_ocd_snomed_clinical = codelist_from_csv(
+    "codelists/user-hjforbes-obsessive-compulsive-disorder-ocd.csv",
+    system="snomed",
+    column="code",
+)
+
+# Anxiety - post traumatic stress disorder
+anxiety_ptsd_snomed_clinical = codelist_from_csv(
+    "codelists/user-hjforbes-post-traumatic-stress-disorder.csv",
+    system="snomed",
+    column="code",
+)
+
+# Eating disorders
+eating_disorders_snomed_clinical = codelist_from_csv(
+    "codelists/user-hjforbes-diagnoses-eating-disorder.csv",
+    system="snomed",
+    column="code",
+)
+
+# Serious mental illness
+serious_mental_illness_snomed_clinical = codelist_from_csv(
+    "codelists/user-hjforbes-severe-mental-illness.csv",
+    system="snomed",
+    column="code",
+)
+
+# Self harm
+self_harm_snomed_clinical = codelist_from_csv(
+    "codelists/user-hjforbes-self-harm.csv",
+    system="snomed",
+    column="code",
+)
+
+# Suicide
+suicide_snomed_clinical = codelist_from_csv(
+    "codelists/user-hjforbes-suicide-icd-10.csv",
+    system="snomed",
+    column="code",
+)
+
+# Addiction
+addiction_snomed_clinical = codelist_from_csv(
+    "codelists/user-hjforbes-opioid-dependency-clinical-diagnosis.csv",
     system="snomed",
     column="code",
 )

--- a/analysis/common_variables.py
+++ b/analysis/common_variables.py
@@ -539,6 +539,132 @@ def generate_common_variables(index_date_variable):
         "tmp_out_date_vte_snomed", "tmp_out_date_vte_hes", "tmp_out_date_vte_death"
     ),
 
+    ## Depression 
+    out_date_depression=patients.with_these_clinical_events(
+        depression_snomed_clinical,
+        returning="date",
+        on_or_after=f"{index_date_variable}",
+        date_format="YYYY-MM-DD",
+        find_first_match_in_period=True,
+        return_expectations={
+            "date": {"earliest": "index_date", "latest" : "today"},
+            "rate": "uniform",
+            "incidence": 0.03,
+        },
+    ),
+
+    ## Anxiety - general
+    out_date_anxiety_general=patients.with_these_clinical_events(
+        anxiety_general_snomed_clinical,
+        returning="date",
+        on_or_after=f"{index_date_variable}",
+        date_format="YYYY-MM-DD",
+        find_first_match_in_period=True,
+        return_expectations={
+            "date": {"earliest": "index_date", "latest" : "today"},
+            "rate": "uniform",
+            "incidence": 0.03,
+        },
+    ),
+
+    ## Anxiety - obsessive compulsive disorder
+    out_date_anxiety_ocd=patients.with_these_clinical_events(
+        anxiety_ocd_snomed_clinical,
+        returning="date",
+        on_or_after=f"{index_date_variable}",
+        date_format="YYYY-MM-DD",
+        find_first_match_in_period=True,
+        return_expectations={
+            "date": {"earliest": "index_date", "latest" : "today"},
+            "rate": "uniform",
+            "incidence": 0.03,
+        },
+    ),
+
+    ## Anxiety - post traumatic stress disorder
+    out_date_anxiety_ptsd=patients.with_these_clinical_events(
+        anxiety_ptsd_snomed_clinical,
+        returning="date",
+        on_or_after=f"{index_date_variable}",
+        date_format="YYYY-MM-DD",
+        find_first_match_in_period=True,
+        return_expectations={
+            "date": {"earliest": "index_date", "latest" : "today"},
+            "rate": "uniform",
+            "incidence": 0.03,
+        },
+    ),
+
+    ## Eating disorders
+    out_date_eating_disorders=patients.with_these_clinical_events(
+        eating_disorders_snomed_clinical,
+        returning="date",
+        on_or_after=f"{index_date_variable}",
+        date_format="YYYY-MM-DD",
+        find_first_match_in_period=True,
+        return_expectations={
+            "date": {"earliest": "index_date", "latest" : "today"},
+            "rate": "uniform",
+            "incidence": 0.03,
+        },
+    ),
+
+    ## Serious mental illness
+    out_date_serious_mental_illness=patients.with_these_clinical_events(
+        serious_mental_illness_snomed_clinical,
+        returning="date",
+        on_or_after=f"{index_date_variable}",
+        date_format="YYYY-MM-DD",
+        find_first_match_in_period=True,
+        return_expectations={
+            "date": {"earliest": "index_date", "latest" : "today"},
+            "rate": "uniform",
+            "incidence": 0.03,
+        },
+    ),
+
+    ## Self harm
+    out_date_self_harm=patients.with_these_clinical_events(
+        self_harm_snomed_clinical,
+        returning="date",
+        on_or_after=f"{index_date_variable}",
+        date_format="YYYY-MM-DD",
+        find_first_match_in_period=True,
+        return_expectations={
+            "date": {"earliest": "index_date", "latest" : "today"},
+            "rate": "uniform",
+            "incidence": 0.03,
+        },
+    ),
+
+    ## Suicide
+    out_date_suicide=patients.with_these_clinical_events(
+        suicide_snomed_clinical,
+        returning="date",
+        on_or_after=f"{index_date_variable}",
+        date_format="YYYY-MM-DD",
+        find_first_match_in_period=True,
+        return_expectations={
+            "date": {"earliest": "index_date", "latest" : "today"},
+            "rate": "uniform",
+            "incidence": 0.03,
+        },
+    ),
+
+    ## Addiction
+    out_date_addiction=patients.with_these_clinical_events(
+        addiction_snomed_clinical,
+        returning="date",
+        on_or_after=f"{index_date_variable}",
+        date_format="YYYY-MM-DD",
+        find_first_match_in_period=True,
+        return_expectations={
+            "date": {"earliest": "index_date", "latest" : "today"},
+            "rate": "uniform",
+            "incidence": 0.03,
+        },
+    ),
+
     # Define covariates (other than sex, which is considered constant and needed for JCVI groupings)
 
     ## Age
@@ -961,25 +1087,25 @@ def generate_common_variables(index_date_variable):
         "tmp_cov_bin_obesity_snomed", "tmp_cov_bin_obesity_hes",
     ),
 
-    ## Depresssion
-    ### Primary care
-    tmp_cov_bin_depression_snomed=patients.with_these_clinical_events(
-        depression_snomed_clinical,
-        returning='binary_flag',
-        on_or_before=f"{index_date_variable}",
-        return_expectations={"incidence": 0.01},
-    ),
-    ### HES APC
-    tmp_cov_bin_depression_hes=patients.admitted_to_hospital(
-        returning='binary_flag',
-        with_these_diagnoses=depression_icd10,
-        on_or_before=f"{index_date_variable}",
-        return_expectations={"incidence": 0.01},
-    ),
-    ### Combined
-    cov_bin_depression=patients.maximum_of(
-        "tmp_cov_bin_depression_snomed", "tmp_cov_bin_depression_hes",
-    ),
+    # ## Depresssion
+    # ### Primary care
+    # tmp_cov_bin_depression_snomed=patients.with_these_clinical_events(
+    #     depression_snomed_clinical,
+    #     returning='binary_flag',
+    #     on_or_before=f"{index_date_variable}",
+    #     return_expectations={"incidence": 0.01},
+    # ),
+    # ### HES APC
+    # tmp_cov_bin_depression_hes=patients.admitted_to_hospital(
+    #     returning='binary_flag',
+    #     with_these_diagnoses=depression_icd10,
+    #     on_or_before=f"{index_date_variable}",
+    #     return_expectations={"incidence": 0.01},
+    # ),
+    # ### Combined
+    # cov_bin_depression=patients.maximum_of(
+    #     "tmp_cov_bin_depression_snomed", "tmp_cov_bin_depression_hes",
+    # ),
 
     ## Chronic obstructive pulmonary disease
     ### Primary care
@@ -1040,6 +1166,102 @@ def generate_common_variables(index_date_variable):
         returning='binary_flag',
         on_or_before=f"{index_date_variable}",
         return_expectations={"incidence": 0.01},
+    ),
+
+    ## Depression 
+    cov_bin_depression=patients.with_these_clinical_events(
+        depression_snomed_clinical,
+        returning='binary_flag',
+        on_or_before=f"{index_date_variable}",
+        return_expectations={"incidence": 0.01},
+    ),
+
+    ## Anxiety - general
+    cov_bin_anxiety_general=patients.with_these_clinical_events(
+        anxiety_general_snomed_clinical,
+        returning='binary_flag',
+        on_or_before=f"{index_date_variable}",
+        return_expectations={"incidence": 0.01},
+    ),
+    
+    ## Anxiety - obsessive compulsive disorder
+    cov_bin_anxiety_ocd=patients.with_these_clinical_events(
+        anxiety_ocd_snomed_clinical,
+        returning='binary_flag',
+        on_or_before=f"{index_date_variable}",
+        return_expectations={"incidence": 0.01},
+    ),
+    
+    ## Anxiety - post traumatic stress disorder
+    cov_bin_anxiety_ptsd=patients.with_these_clinical_events(
+        anxiety_ptsd_snomed_clinical,
+        returning='binary_flag',
+        on_or_before=f"{index_date_variable}",
+        return_expectations={"incidence": 0.01},
+    ),
+
+    ## Eating disorders
+    cov_bin_eating_disorders=patients.with_these_clinical_events(
+        eating_disorders_snomed_clinical,
+        returning='binary_flag',
+        on_or_before=f"{index_date_variable}",
+        return_expectations={"incidence": 0.01},
+    ),
+
+    ## Serious mental illness
+    cov_bin_serious_mental_illness=patients.with_these_clinical_events(
+        serious_mental_illness_snomed_clinical,
+        returning="date",
+        on_or_after=f"{index_date_variable}",
+        date_format="YYYY-MM-DD",
+        find_first_match_in_period=True,
+        return_expectations={
+            "date": {"earliest": "index_date", "latest" : "today"},
+            "rate": "uniform",
+            "incidence": 0.03,
+        },
+    ),
+
+    ## Self harm
+    cov_bin_self_harm=patients.with_these_clinical_events(
+        self_harm_snomed_clinical,
+        returning="date",
+        on_or_after=f"{index_date_variable}",
+        date_format="YYYY-MM-DD",
+        find_first_match_in_period=True,
+        return_expectations={
+            "date": {"earliest": "index_date", "latest" : "today"},
+            "rate": "uniform",
+            "incidence": 0.03,
+        },
+    ),
+
+    ## Suicide
+    cov_bin_suicide=patients.with_these_clinical_events(
+        suicide_snomed_clinical,
+        returning="date",
+        on_or_after=f"{index_date_variable}",
+        date_format="YYYY-MM-DD",
+        find_first_match_in_period=True,
+        return_expectations={
+            "date": {"earliest": "index_date", "latest" : "today"},
+            "rate": "uniform",
+            "incidence": 0.03,
+        },
+    ),
+
+    ## Addiction
+    cov_bin_addiction=patients.with_these_clinical_events(
+        addiction_snomed_clinical,
+        returning="date",
+        on_or_after=f"{index_date_variable}",
+        date_format="YYYY-MM-DD",
+        find_first_match_in_period=True,
+        return_expectations={
+            "date": {"earliest": "index_date", "latest" : "today"},
+            "rate": "uniform",
+            "incidence": 0.03,
+        },
     ),
 
     # Define subgroups (for variables that don't have a corresponding covariate only)

--- a/codelists/codelists.json
+++ b/codelists/codelists.json
@@ -641,6 +641,60 @@
       "url": "https://codelists.opensafely.org/codelist/primis-covid19-vacc-uptake/preg/v1/",
       "downloaded_at": "2021-11-26 11:46:47.969451Z",
       "sha": "16b9bdf6c37c9f5e802912a98542c5dd5d21183d"
+    },
+    "user-hjforbes-depression-symptoms-and-diagnoses.csv": {
+      "id": "user/hjforbes/depression-symptoms-and-diagnoses/499814eb",
+      "url": "https://codelists.opensafely.org/codelist/user/hjforbes/depression-symptoms-and-diagnoses/499814eb/",
+      "downloaded_at": "2022-01-06 13:51:24.419140Z",
+      "sha": "fb7d78483687797b51f106137a809c0e469ca6c0"
+    },
+    "user-hjforbes-anxiety-symptoms-and-diagnoses.csv": {
+      "id": "user/hjforbes/anxiety-symptoms-and-diagnoses/3088a1b6",
+      "url": "https://codelists.opensafely.org/codelist/user/hjforbes/anxiety-symptoms-and-diagnoses/3088a1b6/",
+      "downloaded_at": "2022-01-06 13:51:24.595954Z",
+      "sha": "d5cfd421be9c680373365f60395a6a7b2d0ed82e"
+    },
+    "user-hjforbes-obsessive-compulsive-disorder-ocd.csv": {
+      "id": "user/hjforbes/obsessive-compulsive-disorder-ocd/17792e81",
+      "url": "https://codelists.opensafely.org/codelist/user/hjforbes/obsessive-compulsive-disorder-ocd/17792e81/",
+      "downloaded_at": "2022-01-06 13:51:24.855633Z",
+      "sha": "03a163b6afa744cf5ac8853eed58b2d798805e80"
+    },
+    "user-hjforbes-post-traumatic-stress-disorder.csv": {
+      "id": "user/hjforbes/post-traumatic-stress-disorder/7e69bb4b",
+      "url": "https://codelists.opensafely.org/codelist/user/hjforbes/post-traumatic-stress-disorder/7e69bb4b/",
+      "downloaded_at": "2022-01-06 13:51:25.047204Z",
+      "sha": "d40c357ef9d0f171c9b7322911c6399b700e042f"
+    },
+    "user-hjforbes-diagnoses-eating-disorder.csv": {
+      "id": "user/hjforbes/diagnoses-eating-disorder/62a78820",
+      "url": "https://codelists.opensafely.org/codelist/user/hjforbes/diagnoses-eating-disorder/62a78820/",
+      "downloaded_at": "2022-01-06 13:51:25.225326Z",
+      "sha": "7e6ed67c391b24de8f85adcca66813026596f67d"
+    },
+    "user-hjforbes-severe-mental-illness.csv": {
+      "id": "user/hjforbes/severe-mental-illness/2dd5e1c0",
+      "url": "https://codelists.opensafely.org/codelist/user/hjforbes/severe-mental-illness/2dd5e1c0/",
+      "downloaded_at": "2022-01-06 13:51:25.451546Z",
+      "sha": "34556a280d7c7e90ce823c84930a5209f011ad0e"
+    },
+    "user-hjforbes-self-harm.csv": {
+      "id": "user/hjforbes/self-harm/546314c3",
+      "url": "https://codelists.opensafely.org/codelist/user/hjforbes/self-harm/546314c3/",
+      "downloaded_at": "2022-01-06 13:51:25.803333Z",
+      "sha": "94397e3fe05f9bcc757306d3034b7f4df01c01d4"
+    },
+    "user-hjforbes-suicide-icd-10.csv": {
+      "id": "user/hjforbes/suicide-icd-10/3b53a18e",
+      "url": "https://codelists.opensafely.org/codelist/user/hjforbes/suicide-icd-10/3b53a18e/",
+      "downloaded_at": "2022-01-06 13:51:25.991930Z",
+      "sha": "806be08bebc267e8abb26b8ceeefd713dacb1eb8"
+    },
+    "user-hjforbes-opioid-dependency-clinical-diagnosis.csv": {
+      "id": "user/hjforbes/opioid-dependency-clinical-diagnosis/46e554f5",
+      "url": "https://codelists.opensafely.org/codelist/user/hjforbes/opioid-dependency-clinical-diagnosis/46e554f5/",
+      "downloaded_at": "2022-01-06 13:51:26.157775Z",
+      "sha": "67304f24e3cbffa04852eb4d86c456df75987590"
     }
   }
 }

--- a/codelists/codelists.txt
+++ b/codelists/codelists.txt
@@ -73,7 +73,6 @@ user/hjforbes/angina_hf_icd10/20c03038
 user/RochelleKnight/prostate_cancer_snomed/0437497e
 user/RochelleKnight/prostate_cancer_icd10/6b27d648
 user/RochelleKnight/pregnancy_and_birth_snomed/1d46bcb3
-
 primis-covid19-vacc-uptake/ast/v1
 primis-covid19-vacc-uptake/astadm/v1
 primis-covid19-vacc-uptake/astrx/v1
@@ -107,3 +106,12 @@ primis-covid19-vacc-uptake/longres/v1
 primis-covid19-vacc-uptake/eth2001/v1
 primis-covid19-vacc-uptake/pregdel/v1.2.1
 primis-covid19-vacc-uptake/preg/v1
+user/hjforbes/depression-symptoms-and-diagnoses/499814eb
+user/hjforbes/anxiety-symptoms-and-diagnoses/3088a1b6
+user/hjforbes/obsessive-compulsive-disorder-ocd/17792e81
+user/hjforbes/post-traumatic-stress-disorder/7e69bb4b
+user/hjforbes/diagnoses-eating-disorder/62a78820
+user/hjforbes/severe-mental-illness/2dd5e1c0
+user/hjforbes/self-harm/546314c3
+user/hjforbes/suicide-icd-10/3b53a18e
+user/hjforbes/opioid-dependency-clinical-diagnosis/46e554f5

--- a/codelists/user-hjforbes-anxiety-symptoms-and-diagnoses.csv
+++ b/codelists/user-hjforbes-anxiety-symptoms-and-diagnoses.csv
@@ -1,0 +1,82 @@
+code,term
+102915009,Nosophobia
+1037391000000102,Anxiety resolved
+1037451000000103,Referral for psychological management of anxiety
+1037471000000107,Referral for psychological management of anxiety declined
+1053831000000101,Signposting to Anxiety UK
+1057311000000107,Signposting to Obsessive-Compulsive Disorder-UK
+1057321000000101,Signposting to Obsessive-Compulsive Disorder Action
+111475002,Neurosis
+11806006,Separation anxiety disorder of childhood
+12479006,Compulsive behavior
+13438001,Overanxious disorder of childhood
+162723006,On examination - anxious
+162724000,On examination - nervous
+17496003,Organic anxiety disorder
+183399002,Antiphobic therapy
+191708009,Chronic anxiety
+191709001,Recurrent anxiety
+191722009,Agoraphobia with panic attacks
+191723004,Agoraphobia without mention of panic attacks
+191724005,"Social phobia, fear of eating in public"
+191725006,"Social phobia, fear of public speaking"
+191726007,"Social phobia, fear of public washing"
+191728008,Fear of crowds
+191733007,Fear of pregnancy
+191736004,Obsessive-compulsive disorder
+191737008,Compulsive neurosis
+191738003,Obsessional neurosis
+191952007,Somatoform autonomic dysfunction - respiratory tract
+191962000,Neurocirculatory asthenia
+192042008,Acute post-trauma stress state
+192108001,Disturbance of anxiety and fearfulness in childhood and adolescence
+192611004,Childhood phobic anxiety disorder
+197480006,Anxiety disorder
+198288003,Anxiety state
+19887002,Claustrophobia
+199101000000102,Referral for guided self-help for anxiety
+207363009,Anxiety neurosis
+21897009,Generalized anxiety disorder
+225624000,Panic attack
+228560001,Anxiety management training
+231501003,Needle phobia
+231504006,Mixed anxiety and depressive disorder
+247853008,Fear of flying
+247854002,Flying phobia
+25501002,Social phobia
+268957000,"Neurotic condition, insight present"
+271947006,School phobia
+271952001,Stress and adjustment reaction
+276242008,Fear of water
+313087008,Counseling for anxiety
+313387002,Phonophobia
+34563004,Fear of getting cancer
+371631005,Panic disorder
+38617005,Dental phobia
+386808001,Phobia
+386810004,Phobic disorder
+395017009,Complaining of panic attack
+417676004,On examination - panic attack
+446175003,Acute posttraumatic stress disorder following military combat
+446180007,Delayed posttraumatic stress disorder following military combat
+47505003,Posttraumatic stress disorder
+48694002,Anxiety
+54307006,Zoophobia
+54587008,Simple phobia
+563201000000101,Phobic disorder NOS
+56576003,Panic disorder without agoraphobia
+58963008,Acrophobia
+61157009,Combat fatigue
+61569007,Agoraphobia without history of panic disorder
+620181000000106,Other post-traumatic stress disorder
+64165008,Avoidant disorder of childhood
+67195008,Acute stress disorder
+67431008,Compulsion expressed as ritual
+67698009,Obsessional thoughts
+699241002,Chronic post-traumatic stress disorder following military combat
+702535006,Anxiety about breathlessness
+70691001,Agoraphobia
+710060004,Management of anxiety
+861611000000100,Education about anxiety
+908541000000103,Patient given advice about management of anxiety
+933461000000100,Referral for guided self-help for anxiety declined

--- a/codelists/user-hjforbes-depression-symptoms-and-diagnoses.csv
+++ b/codelists/user-hjforbes-depression-symptoms-and-diagnoses.csv
@@ -1,0 +1,154 @@
+code,term
+1038261000000100,Maternal postnatal depression
+104851000119103,Postpartum major depression in remission
+1057351000000106,Signposting to depression self-help group
+1086471000000103,"Recurrent reactive depressive episodes, severe, with psychosis"
+1086661000000108,"Reactive depression, prolonged single episode"
+1089511000000100,Recurrent depression with current severe episode and psychotic features
+1089631000000109,Recurrent depression with current severe episode without psychotic features
+1089641000000100,Recurrent depression with current moderate episode
+112001000119100,Positive screening for depression on Patient Health Questionnaire 9
+14183003,"Chronic major depressive disorder, single episode"
+15639000,"Moderate major depression, single episode"
+16238181000119101,Depressive disorder caused by amphetamine
+16238221000119109,Depressive disorder caused by methamphetamine
+16264621000119109,Recurrent mild major depressive disorder co-occurrent with anxiety
+16264821000119108,Recurrent severe major depressive disorder co-occurrent with anxiety
+16264901000119109,Recurrent moderate major depressive disorder co-occurrent with anxiety
+16265061000119105,Recurrent major depressive disorder co-occurrent with anxiety in full remission
+16265301000119106,Recurrent major depressive disorder in partial remission co-occurrent with anxiety
+16265951000119109,Mild major depressive disorder co-occurrent with anxiety single episode
+16266831000119100,Moderate major depressive disorder co-occurrent with anxiety single episode
+16266991000119108,Severe major depressive disorder co-occurrent with anxiety single episode
+162722001,On examination - depressed
+166291000000108,Depression enhanced services administration
+166481000000107,Depression enhanced service completed
+18818009,Moderate recurrent major depression
+191455000,Presenile dementia with depression
+191459006,Senile dementia with depression
+191495003,Drug-induced depressive state
+191601008,"Single major depressive episode, mild"
+191602001,"Single major depressive episode, moderate"
+191604000,"Single major depressive episode, severe, with psychosis"
+191606003,"Single major depressive episode, in full remission"
+191610000,"Recurrent major depressive episodes, mild"
+191611001,"Recurrent major depressive episodes, moderate"
+191613003,"Recurrent major depressive episodes, severe, with psychosis"
+191615005,"Recurrent major depressive episodes, in full remission"
+191616006,Recurrent depression
+191632009,"Bipolar affective disorder, currently depressed, severe, with psychosis"
+191634005,"Bipolar affective disorder, currently depressed, in full remission"
+191659001,Atypical depressive disorder
+191676002,Reactive depressive psychosis
+192046006,Brief depressive adjustment reaction
+192049004,Prolonged depressive adjustment reaction
+192079006,Postviral depression
+192080009,Chronic depression
+192362008,"Bipolar affective disorder, current episode mixed"
+19527009,Single episode of major depression in full remission
+196381000000100,Depression resolved
+199111000000100,Referral for guided self-help for depression
+20250007,"Severe major depression, single episode, with psychotic features, mood-incongruent"
+231443008,Right hemispheric organic affective disorder
+231485007,Post-schizophrenic depression
+231499006,Endogenous depression first episode
+231500002,Masked depression
+231504006,Mixed anxiety and depressive disorder
+231542000,Depressive conduct disorder
+23645006,Organic mood disorder
+247803002,Seasonal affective disorder
+251000119105,"Severe major depression, single episode"
+25922000,"Major depressive disorder, single episode with postpartum onset"
+268620009,Single major depressive episode
+268621008,Recurrent major depressive episodes
+272022009,Complaining of feeling depressed
+272024005,Complaining of feeling unhappy
+274948002,Endogenous depression - recurrent
+28475009,Severe recurrent major depression with psychotic features
+288751000119101,"Reactive depressive psychosis, single episode"
+300706003,Endogenous depression
+30605009,Major depression in partial remission
+30819006,Dysphoric mood
+310495003,Mild depression
+310496002,Moderate depression
+310497006,Severe depression
+321717001,Involutional depression
+33135002,Recurrent major depression in partial remission
+35489007,Depressive disorder
+357705009,Cotard's syndrome
+361761000000106,On full dose long term treatment for depression
+36474008,Severe recurrent major depression without psychotic features
+366979004,Depressed mood
+36923009,"Major depression, single episode"
+370143000,Major depressive disorder
+386782008,Disturbance in affect
+394924000,Symptoms of depression
+395072006,Counseling for postnatal depression
+397701000000102,[X]Severe depressive episode without psychotic symptoms
+397711000000100,[X]Severe depressive episode with psychotic symptoms
+401174001,Depression management program
+401211000000106,[X] Single episode major depression without psychotic symptoms
+40379007,Mild recurrent major depression
+40568001,Recurrent brief depressive disorder
+413169006,On depression register
+413972000,Depression annual review
+413973005,Depression interim review
+413974004,Depression medication review
+415044007,Patient given advice about management of depression
+426578000,Premenstrual dysphoric disorder in remission
+42810003,Major depression in remission
+429124005,History of mood disorder
+42925002,"Major depressive disorder, single episode with atypical features"
+430421000000104,[X]Mild depressive episode
+455731000000100,[X] Single episode agitated depression without psychotic symptoms
+46206005,Mood disorder
+46244001,Recurrent major depression in full remission
+465441000000108,[X]Moderate depressive episode
+467361000000105,"[X] Manic-depressive psychosis, depressed type without psychotic symptoms"
+473126001,Suspected depressive disorder
+57194009,Adjustment disorder with depressed mood
+58703003,Postpartum depression
+609311000000100,Depressive disorder NEC
+63412003,Major depression in full remission
+63778009,"Major depressive disorder, single episode with melancholic features"
+68019004,Recurrent major depression in remission
+69392006,"Major depressive disorder, single episode with catatonic features"
+698957003,Depressive disorder in remission
+70747007,"Major depression single episode, in partial remission"
+713831000000108,Depression monitoring administration
+715831000000109,Excepted from depression quality indicators - informed dissent
+716111000000102,Exception reporting - depression quality indicators
+716421000000103,Depression monitoring telephone invitation
+716681000000100,Depression monitoring second letter
+716831000000103,Excepted from depression quality indicators - patient unsuitable
+716961000000102,Depression monitoring third letter
+717211000000107,Depression monitoring first letter
+717261000000109,Depression monitoring verbal invitation
+720453001,Moderately severe major depression single episode
+720454007,Minimal major depression single episode
+73867007,Severe major depression with psychotic features
+74506000,Bereavement due to life event
+75084000,Severe major depression without psychotic features
+755321000000106,"Single major depressive episode, severe, with psychosis, psychosis in remission"
+755331000000108,"Recurrent major depressive episodes, severe, with psychosis, psychosis in remission"
+76441001,"Severe major depression, single episode, without psychotic features"
+764611000000100,"Recurrent major depressive episodes, severe"
+764631000000108,"Single major depressive episode, severe"
+764691000000109,"Recurrent major depressive episodes, in partial remission"
+764711000000106,"Single major depressive episode, in remission"
+765176007,Psychosis and severe depression co-occurrent and due to bipolar affective disorder
+774531000000101,Antidepressant drug treatment started
+77911002,"Severe major depression, single episode, with psychotic features, mood-congruent"
+784051000000106,Depression care management
+78667006,Dysthymia
+788120007,Antenatal depression
+790961000000101,Antenatal depression
+79298009,"Mild major depression, single episode"
+82218004,Postoperative depression
+832007,Moderate major depression
+83458005,Agitated depression
+84760002,"Schizoaffective disorder, depressive type"
+87414006,Reactive depression (situational)
+87512008,Mild major depression
+923921000000104,Referral for depression self-help video
+933441000000101,Referral for guided self-help for depression declined

--- a/codelists/user-hjforbes-diagnoses-eating-disorder.csv
+++ b/codelists/user-hjforbes-diagnoses-eating-disorder.csv
@@ -1,0 +1,72 @@
+code,term
+139082003,Appetite loss: [anorexia] or [anorexia symptom]
+14077003,Pica
+154926005,Anorexia nervosa
+154938001,(Eating disorder: [bulimia - nonorganic] or [psychogenic overeating] or [NOS - psychogenic]) or (pica) or (infant feeding problem)
+158268008,[D]Anorexia
+158272007,[D]Anorexia NOS
+161826006,Appetite loss: [anorexia] or [anorexia symptom]
+192011003,Other and unspecified non-organic eating disorders
+192012005,Unspecified non-organic eating disorder
+192013000,Compulsive eating disorder (& [bulimia including non-organic overeating])
+192017004,Non-organic loss of appetite
+192020007,Other specified non-organic eating disorder
+192021006,Non-organic eating disorder NOS
+192444003,[X]Eating disorders
+192445002,Anorexia nervosa
+192446001,Atypical anorexia nervosa
+192447005,[X] (Bulimia nervosa) or (bulimia NOS) or (hyperorexia nervosa)
+192448000,Atypical bulimia nervosa
+192451007,[X] Eating disorders: [other] or [pica in adults] or [psychogenic loss of appetite]
+192452000,"[X]Eating disorder, unspecified"
+192631000,Pica of infancy and childhood
+206915006,[D]Anorexia
+206917003,[D]Anorexia NOS
+206939001,[D]Excessive eating
+231522009,Atypical anorexia nervosa
+231523004,Atypical bulimia nervosa
+248118000,Self-induced purging to lose weight
+248122005,Binging
+249468005,Anorexia symptom
+267023007,Excessive eating - polyphagia
+268721001,[X]Other eating disorders
+268779001,(Eating disorder: [bulimia - nonorganic] or [psychogenic overeating] or [NOS - psychogenic]) or (pica) or (infant feeding problem)
+269813009,Appetite loss - anorexia
+270902002,Overeating associated with other psychological disturbances
+313076000,Counseling for eating disorder
+32721004,"Bulimia nervosa, purging type"
+386264009,Eating disorders management
+400973003,Referral to eating disorders clinic
+403313001,Hypertrichosis in anorexia nervosa
+407666007,Nocturnal sleep-related eating disorder
+410721000000104,[X]Other eating disorders
+413721000000105,[X]Eating disorders
+413861000000106,[X] Eating disorders: [other] or [pica in adults] or [psychogenic loss of appetite]
+427857000,Dietary education for eating disorder
+432541000000106,[D]Anorexia NOS
+439437006,Seen in eating disorder clinic
+451151000000109,[D]Anorexia NOS
+468041000000107,"[X]Eating disorder, unspecified"
+496871000000107,[D]Anorexia
+497061000000105,[D]Excessive eating
+56882008,Anorexia nervosa
+59645001,"Bulimia nervosa, nonpurging type"
+608241000000102,Other and unspecified non-organic eating disorders
+608251000000104,Unspecified non-organic eating disorder
+608261000000101,Other specified non-organic eating disorder
+608271000000108,Non-organic eating disorder NOS
+63393005,"Anorexia nervosa, binge-eating purging type"
+698695006,Anorexia nervosa in remission
+705001007,Self-induced vomiting to lose weight
+705002000,Repeated self-induced vomiting
+722959000,Anorexia nervosa co-occurrent with dangerously low body weight
+722960005,Anorexia nervosa co-occurrent with significantly low body weight
+72366004,Eating disorder
+723917005,Dangerously low body weight co-occurrent and due to anorexia nervosa of restricting type
+723918000,Dangerously low body weight co-occurrent and due to anorexia nervosa of binge-eating purging type
+723919008,Significantly low body weight co-occurrent and due to anorexia nervosa of restricting type
+723920002,Significantly low body weight co-occurrent and due to anorexia nervosa of binge-eating purging type
+77675002,"Anorexia nervosa, restricting type"
+78004001,Bulimia nervosa
+782949007,"Facial dysmorphism, anorexia, cachexia, eye and skin anomalies syndrome"
+962011000000105,Eating disorder care plan

--- a/codelists/user-hjforbes-obsessive-compulsive-disorder-ocd.csv
+++ b/codelists/user-hjforbes-obsessive-compulsive-disorder-ocd.csv
@@ -1,0 +1,6 @@
+code,term
+1057311000000107,Signposting to Obsessive-Compulsive Disorder-UK
+1057321000000101,Signposting to Obsessive-Compulsive Disorder Action
+191736004,Obsessive-compulsive disorder
+191737008,Compulsive neurosis
+191738003,Obsessional neurosis

--- a/codelists/user-hjforbes-opioid-dependency-clinical-diagnosis.csv
+++ b/codelists/user-hjforbes-opioid-dependency-clinical-diagnosis.csv
@@ -1,0 +1,75 @@
+code,term
+13187008,Poisoning caused by heroin
+14784000,Opioid-induced organic mental disorder
+191816009,Drug dependence
+191818005,Unspecified opioid dependence
+191819002,Continuous opioid dependence
+191820008,Episodic opioid dependence
+191821007,Opioid dependence in remission
+191865004,Combined opioid with non-opioid drug dependence
+191867007,"Combined opioid with non-opioid drug dependence, continuous"
+191868002,"Combined opioid with non-opioid drug dependence, episodic"
+191869005,Combined opioid with non-opioid drug dependence in remission
+191909007,Nondependent opioid abuse
+191912005,"Nondependent opioid abuse, continuous"
+191913000,"Nondependent opioid abuse, episodic"
+191914006,Nondependent opioid abuse in remission
+198021000000102,Buprenorphine maintenance therapy
+200021000000100,Drug addiction detoxification therapy - methadone
+200031000000103,Drug addiction maintenance therapy - methadone
+202991000000100,Heroin misuse
+205231000000102,Opiate dependence detoxification
+206121000000104,Drug addiction maintenance therapy - buprenorphine
+206131000000102,Drug addiction detoxification therapy - buprenorphine
+216463005,Accidental poisoning caused by heroin
+226034001,Injecting drug user
+228388006,Intravenous drug user
+228389003,Groin injector
+228391006,Drug injection behavior
+228395002,Shares drug injecting equipment
+228396001,Does not share drug injection equipment
+231477003,Heroin dependence
+231478008,Methadone dependence
+231479000,Morphine dependence
+231480002,Opium dependence
+23951000087100,Opioid dependence service
+23961000087102,Opioid dependency management specialty
+248601000000106,Neck injector
+276981000000107,History of opiate misuse
+277091000000105,History of methadone misuse
+277221000000102,History of daily heroin misuse
+277251000000107,History of weekly heroin misuse
+277281000000101,Previous history of heroin misuse
+277311000000103,History of infrequent heroin misuse
+277341000000102,History of daily methadone misuse
+277371000000108,History of weekly methadone misuse
+277401000000105,History of infrequent methadone misuse
+277431000000104,Previous history of methadone misuse
+277941000000101,History of daily opiate misuse
+277971000000107,History of weekly opiate misuse
+278001000000102,History of infrequent opiate misuse
+278031000000108,Previous history of opiate misuse
+279441000000100,History of heroin misuse
+279461000000104,Using heroin on top of substitution therapy
+279491000000105,Not using heroin on top of substitution therapy
+286841000000101,Reinduction to methadone maintenance therapy
+286871000000107,Reinduction to buprenorphine maintenance therapy
+292056009,Diamorphine adverse reaction
+295174006,Heroin overdose
+304681000000107,Opioid agonist substitution therapy
+310653000,Drug addiction therapy using methadone
+371435006,History of drug abuse
+391102000,Failed heroin detoxification
+416479009,Previously injecting drug user
+5602001,Opioid abuse
+645601000000104,Unspecified opioid dependence
+712545004,Abstinent from drug misuse on maintenance replacement
+75544000,Opioid dependence
+763699005,Clinical Opiate Withdrawal Scale score
+768691000000103,Drug addiction maintenance therapy - naltrexone
+768711000000101,Drug addiction maintenance therapy - lofexidine
+77721001,Opioid intoxication
+87132004,Opioid withdrawal
+891951000000109,Opioid substitution therapy monitoring
+91388009,Psychoactive substance abuse
+943071000000104,Opioid-induced psychosis

--- a/codelists/user-hjforbes-post-traumatic-stress-disorder.csv
+++ b/codelists/user-hjforbes-post-traumatic-stress-disorder.csv
@@ -1,0 +1,7 @@
+code,term
+102915009,Nosophobia
+446175003,Acute posttraumatic stress disorder following military combat
+446180007,Delayed posttraumatic stress disorder following military combat
+47505003,Posttraumatic stress disorder
+620181000000106,Other post-traumatic stress disorder
+699241002,Chronic post-traumatic stress disorder following military combat

--- a/codelists/user-hjforbes-self-harm.csv
+++ b/codelists/user-hjforbes-self-harm.csv
@@ -1,0 +1,246 @@
+code,term
+10486009,Poisoning caused by medazepam
+105624005,"Poisoning caused by analgesic, antipyretic AND/OR antirheumatic"
+111763008,Poisoning caused by mixed sedative
+111765001,Poisoning caused by prochlorperazine
+12898000,Poisoning caused by pentazocine
+130968006,Self-mutilation
+161474000,History of attempted suicide
+161589007,History of poisoning
+16248006,Poisoning caused by butyrophenone-based tranquilizer
+18052008,Poisoning caused by meperidine
+20260003,Poisoning caused by psychostimulant
+212597004,Phenacetin poisoning
+212602006,Ibuprofen poisoning
+212603001,Naproxen poisoning
+212609002,Other analgesic and antipyretic poisoning
+212612004,Other analgesic or antipyretic poisoning NOS
+212641008,Central nervous system muscle-tone depressant poisoning
+212658003,Spiperone poisoning
+212664005,Hydroxyzine poisoning
+213769004,Causes of injury and poisoning
+219108005,"Suicide and selfinflicted poisoning by analgesics, antipyretics and anti-rheumatics"
+219122005,Self poisoning by corrosive or caustic substance
+219123000,Self poisoning caused by arsenic or its compounds
+219125007,Suicide and selfinflicted poisoning by gases in domestic use
+219126008,Suicide and selfinflicted poisoning by gas distributed by pipeline
+219127004,Suicide and selfinflicted poisoning by liquefied petroleum gas distributed in mobile containers
+219131005,Self poisoning caused by motor vehicle exhaust gas
+219137009,Suicide or attempted suicide by hanging
+219141008,Suicide and selfinflicted injury by drowning
+219142001,Suicide or selfinflicted injury by firearms and explosives
+219150005,Suicide or selfinflicted injury by cutting and stabbing
+219151009,Suicide or selfinflicted injury by cutting
+219152002,Self inflicted lacerations to wrist
+219153007,Suicide or selfinflicted injury by stabbing
+219155000,Suicide or self injury by jumping from a height
+219168008,Suicide or self injury by electric current
+219174008,Late effect of self inflicted injury
+219187002,Assault by poisoning by drugs or medicines
+219328003,"Hanging, strangulation or suffocation of unknown intent"
+219340003,Injury of unknown intent by explosive
+219342006,Injury of unknown intent by sharp instrument
+219343001,Injury of unknown intent by cutting instrument
+219344007,Injury of unknown intent by stabbing instrument
+219359001,Injury of unknown intent by electrocution
+224948000,Throwing self in front of vehicle
+241748001,Poisoning caused by analgesic drug
+241750009,Poisoning caused by dihydrocodeine
+241756003,Poisoning caused by anesthetic agent
+241757007,Poisoning caused by temazepam
+241762008,Poisoning caused by beta-adrenergic blocking drug
+241767002,Antipyretic poisoning
+241769004,Organic solvents causing toxic effect
+242836008,Self poisoning by non-drug solid or liquid agents
+242837004,Self poisoning by paraquat
+242839001,Self poisoning by gas
+248062006,Self-injurious behavior
+248073004,Cutting self
+25980005,Poisoning caused by secobarbital
+269268004,Central nervous system depressants and anesthetic agent poisoning
+269688005,"Accidental poisoning caused by drugs, medicines and biologicals"
+269725004,Suicide and selfinflicted injury
+269726003,Suicide and selfinflicted injury by suffocation by plastic bag
+269735005,Injury undetermined whether accidentally or purposely inflicted
+269808005,Attempt suicide - car exhaust
+271982007,Intentional self poisoning
+274912004,Self poisoning by agricultural chemical
+275385007,Poisoning caused by biological substance
+276853009,Self inflicted injury
+284744004,Burning self
+284756003,Hitting self
+285142001,Self-scalding
+287181000,Attempted suicide - hanging
+287182007,Attempted suicide - suffocation
+287183002,Attempted suicide - drowning
+287184008,Attempted suicide - firearms
+287185009,Attempted suicide - cut/stab
+287186005,Attempted suicide - jumping from a high place
+288293001,Poisoning caused by central nervous system drug
+288311002,Attempt suicide - domestic gas
+290133008,Poisoning caused by nonopioid analgesic
+290162009,Dextropropoxyphene poisoning
+290221007,Intentional narcotic poisoning
+290273008,Mefenamic acid poisoning
+290486002,General anesthetic drug poisoning
+290923004,Trazodone poisoning
+291190004,Thioridazine poisoning
+295124009,Acetaminophen overdose
+295250003,Ibuprofen overdose
+295830007,Overdose of antidepressant drug
+295835002,Amitriptyline overdose
+295918002,Selective serotonin re-uptake inhibitor overdose
+296015009,Sedative overdose
+296036006,Barbiturate overdose
+296037002,Amylobarbitone overdose
+296039004,Intentional amylobarbitone overdose
+296053004,Benzodiazepine overdose
+296058008,Flurazepam overdose
+296070007,Nitrazepam overdose
+296118008,Diazepam overdose
+296125001,Overdose of temazepam
+314550003,History of deliberate self harm
+32835006,Poisoning caused by autonomous nervous system drug
+362977000,Sequela
+36784008,Poisoning caused by flurazepam
+37131007,Pesticide poisoning
+385231000000108,"[X]Intentional self harm by drowning and submersion, occurrence at sports and athletics area"
+385441000000100,"[X]Intentional self harm by sharp object, occurrence at sports and athletics area"
+385451000000102,"[X]Intentional self harm by sharp object, occurrence on street and highway"
+385461000000104,"[X]Intentional self harm by sharp object, occurrence at trade and service area"
+385481000000108,"[X]Intentional self harm by other and unspecified firearm discharge, occurrence on farm"
+385491000000105,"[X]Intentional self harm by sharp object, occurrence at industrial and construction area"
+385501000000104,"[X]Intentional self harm by sharp object, occurrence on farm"
+385601000000100,"[X]Intentional self poisoning by and exposure to narcotic drugs, occurrence in residential institution"
+385711000000109,"[X]Intentional self poisoning by and exposure to nonopioid analgesics, occurrence on street and highway"
+385731000000101,"[X]Intentional self poisoning by and exposure to nonopioid analgesics, occurrence at industrial and construction area"
+387051000000104,"[X]Intentional self harm by rifle, shotgun and larger firearm discharge"
+387071000000108,"[X]Intentional self poisoning by and exposure to nonopioid analgesics, occurrence at sports and athletics area"
+390867000,History of repeated overdose
+391791000000102,"[X]Intentional self poisoning by and exposure to pesticides, occurrence at industrial and construction area"
+391801000000103,"[X]Intentional self harm by handgun discharge, occurrence in residential institution"
+391821000000107,"[X]Intentional self harm by hanging, strangulation and suffocation, occurrence at unspecified place"
+392001000000101,"[X]Intentional self poisoning by and exposure to pesticides, occurrence at school, other institution and public administrative area"
+392011000000104,"[X]Intentional self harm by drowning and submersion, occurrence at trade and service area"
+392021000000105,"[X]Intentional self harm by drowning and submersion, occurrence at industrial and construction area"
+392031000000107,"[X]Intentional self harm by drowning and submersion, occurrence on farm"
+392501000000107,"[X]Intentional self harm by jumping from a high place, occurrence at unspecified place"
+392701000000104,"[X]Intentional self poisoning by and exposure to pesticides, occurrence at home"
+393011000000105,"[X]Intentional self poisoning by and exposure to narcotic drugs, occurrence at trade and service area"
+393111000000106,"[X]Intentional self harm by handgun discharge, occurrence on street and highway"
+393331000000100,"[X]Intentional self poisoning by and exposure to narcotic drugs, occurrence on farm"
+393341000000109,"[X]Intentional self poisoning by and exposure to nonopioid analgesics, occurrence at home"
+393841000000101,"[X]Intentional self harm by handgun discharge, occurrence at unspecified place"
+393871000000107,"[X]Intentional self harm by rifle, shotgun and larger firearm discharge, occurrence at home"
+393881000000109,"[X]Intentional self harm by rifle, shotgun and larger firearm discharge, occurrence in residential institution"
+403581000000101,"[X]Intentional self poisoning by and exposure to pesticides, occurrence at unspecified place"
+403582001,Self-inflicted caustic burn
+403641000000108,[X]Intentional self harm by other and unspecified firearm discharge
+403671000000102,"[X]Intentional self harm by other and unspecified firearm discharge, occurrence at school, other institution and public administrative area"
+403681000000100,"[X]Intentional self poisoning by and exposure to narcotic drugs, occurrence at unspecified place"
+404741000000103,"[X]Intentional self harm by rifle, shotgun and larger firearm discharge, occurrence on farm"
+404831000000101,"[X]Intentional self harm by other and unspecified firearm discharge, occurrence on street and highway"
+405051000000103,"[X]Intentional self harm by handgun discharge, occurrence at school, other institution and public administrative area"
+405061000000100,"[X]Intentional self harm by handgun discharge, occurrence at sports and athletics area"
+40748005,Poisoning caused by intravenous anesthetic
+415591000000101,"[X]Intentional self harm by drowning and submersion, occurrence at unspecified place"
+41839000,Poisoning caused by thiopental sodium
+418420002,Intentionally harming self
+420511000000107,"[X]Intentional self harm by handgun discharge, occurrence at home"
+420741000000104,"[X]Intentional self poisoning by and exposure to pesticides, occurrence in residential institution"
+421331000000103,"[X]Intentional self harm by rifle, shotgun and larger firearm discharge, occurrence at sports and athletics area"
+421581000000105,"[X]Intentional self poisoning by and exposure to narcotic drugs, occurrence at school, other institution and public administrative area"
+422691000000103,"[X]Intentional self harm by handgun discharge, occurrence at other specified place"
+422721000000107,"[X]Intentional self poisoning by and exposure to nonopioid analgesics, occurrence at school, other institution and public administrative area"
+42377002,Poisoning caused by anticonvulsant
+431307001,Intentional poisoning caused by drug
+432991000000105,"[X]Intentional self harm by rifle, shotgun and larger firearm discharge, occurrence at other specified place"
+433281000000106,"[X]Intentional self harm by other and unspecified firearm discharge, occurrence at home"
+433701000000106,"[X]Intentional self harm by sharp object, occurrence at other specified place"
+433941000000106,"[X]Intentional self poisoning by and exposure to narcotic drugs, occurrence at home"
+434241000000100,"[X]Intentional self harm by hanging, strangulation and suffocation, occurrence at home"
+434261000000104,"[X]Intentional self harm by handgun discharge, occurrence on farm"
+44003006,Poisoning caused by barbiturate
+441931000000102,[X]Poisoning by other antiepileptic and sedative-hypnotic drugs
+44301001,Suicide
+445021000000102,"[X]Intentional self harm by rifle, shotgun and larger firearm discharge, occurrence at unspecified place"
+445311000000106,"[X]Intentional self poisoning by and exposure to pesticides, occurrence at sports and athletics area"
+445341000000107,"[X]Intentional self poisoning by and exposure to pesticides, occurrence at other specified place"
+445351000000105,"[X]Intentional self harm by other and unspecified firearm discharge, occurrence at sports and athletics area"
+445891000000109,"[X]Intentional self harm by other and unspecified firearm discharge, occurrence at other specified place"
+445901000000105,"[X]Intentional self harm by other and unspecified firearm discharge, occurrence at unspecified place"
+445911000000107,"[X]Intentional self harm by sharp object, occurrence at unspecified place"
+446251000000108,"[X]Intentional self harm by rifle, shotgun and larger firearm discharge, occurrence on street and highway"
+446551000000106,"[X]Intentional self harm by sharp object, occurrence at home"
+446651000000105,"[X]Intentional self poisoning by and exposure to narcotic drugs, occurrence at sports and athletics area"
+446661000000108,"[X]Intentional self poisoning by and exposure to narcotic drugs, occurrence on street and highway"
+446791000000109,"[X]Intentional self poisoning by and exposure to narcotic drugs, occurrence at industrial and construction area"
+446891000000101,[X]Intentional self harm by drowning and submersion
+446901000000100,[X]Intentional self poisoning by and exposure to nonopioid analgesics
+457141000000100,"[X]Intentional self poisoning by and exposure to pesticides, occurrence on street and highway"
+457161000000104,"[X]Intentional self poisoning by and exposure to pesticides, occurrence at trade and service area"
+457321000000105,"[X]Intentional self harm by drowning and submersion, occurrence at school, other institution and public administrative area"
+457331000000107,"[X]Intentional self harm by drowning and submersion, occurrence on street and highway"
+457721000000106,"[X]Intentional self harm by other and unspecified firearm discharge, occurrence at industrial and construction area"
+458171000000105,"[X]Intentional self poisoning by and exposure to nonopioid analgesics, occurrence on farm"
+458281000000101,"[X]Intentional self harm by drowning and submersion, occurrence at home"
+458381000000105,"[X]Intentional self harm by handgun discharge, occurrence at trade and service area"
+458391000000107,"[X]Intentional self harm by handgun discharge, occurrence at industrial and construction area"
+458531000000103,"[X]Intentional self harm by other and unspecified firearm discharge, occurrence at trade and service area"
+458971000000107,"[X]Intentional self poisoning by and exposure to narcotic drugs, occurrence at other specified place"
+459381000000104,"[X]Intentional self poisoning by and exposure to nonopioid analgesics, occurrence at other specified place"
+459421000000108,"[X]Intentional self poisoning by and exposure to nonopioid analgesics, occurrence at unspecified place"
+459811000000100,"[X]Intentional self harm by sharp object, occurrence in residential institution"
+459821000000106,"[X]Intentional self harm by sharp object, occurrence at school, other institution and public administrative area"
+461331000000108,[X]Intentional self poisoning by and exposure to pesticides
+461371000000105,[X]Intentional self poisoning by and exposure to noxious substances
+472681000000104,"[X]Intentional self harm by drowning and submersion, occurrence at other specified place"
+472701000000102,[X]Intentional self harm by handgun discharge
+472721000000106,"[X]Intentional self poisoning by and exposure to pesticides, occurrence on farm"
+472751000000101,"[X]Intentional self harm by other and unspecified firearm discharge, occurrence in residential institution"
+473128000,Suspected drug overdose
+473371000000101,"[X]Intentional self harm by rifle, shotgun and larger firearm discharge, occurrence at trade and service area"
+473621000000105,"[X]Intentional self poisoning by and exposure to nonopioid analgesics, occurrence at trade and service area"
+473731000000102,"[X]Intentional self harm by drowning and submersion, occurrence in residential institution"
+473791000000101,"[X]Intentional self harm by hanging, strangulation and suffocation, occurrence in residential institution"
+474461000000102,"[X]Intentional self poisoning by and exposure to nonopioid analgesics, occurrence in residential institution"
+47836003,Poisoning caused by morphine
+4836003,Poisoning caused by anti-parkinsonism drug
+48534006,Poisoning caused by phenothiazine-based tranquilizer
+48981002,Parasuicide
+518431000000101,Intentional overdose of prescription only medication
+52703008,Poisoning caused by propranolol
+55680006,Drug overdose
+57335002,"Toxic effect of gas, fumes AND/OR vapors"
+59274003,Intentional drug overdose
+6024006,Poisoning caused by nitrazepam
+61406000,Poisoning caused by diazepam
+61438005,Poisoning caused by psychotropic agent
+61803000,Poisoning caused by central nervous system stimulant
+64921004,Poisoning caused by phenobarbital
+65425009,Poisoning caused by imipramine
+671461000000102,"Analgesic poisoning, NEC"
+67426006,Toxic effect of alcohol
+676361000000101,Drug and medicament poisoning NOS
+681111000000102,Suicide and self inflicted poisoning by drug or medicine NOS
+684281000000100,Suicide and self inflicted injury NOS
+70273001,Poisoning caused by paracetamol
+70330008,Poisoning caused by lorazepam
+7248001,Poisoning caused by salicylate
+73108003,Poisoning caused by trifluperidol
+75478009,Poisoning
+78695006,Poisoning caused by amitriptyline
+7895008,Poisoning caused by drug AND/OR medicinal substance
+81914009,Poisoning caused by benzodiazepine-based tranquilizer
+82276009,Poisoning caused by antidepressant
+82313006,Suicide attempt
+844631000000104,Acute renal failure induced by poison
+84483000,Poisoning caused by chlordiazepoxide
+85337000,Poisoning caused by sedative AND/OR hypnotic
+85975005,Poisoning caused by psychodysleptic
+87363009,Poisoning caused by promazine
+87396006,Poisoning caused by chlorpromazine
+88993007,Poisoning caused by haloperidol
+89715001,Poisoning caused by phenylbutazone
+91267002,Poisoning caused by fluphenazine
+9291000,Poisoning caused by monoamine oxidase inhibitor

--- a/codelists/user-hjforbes-severe-mental-illness.csv
+++ b/codelists/user-hjforbes-severe-mental-illness.csv
@@ -1,0 +1,439 @@
+code,term
+102940002,Schizophrenic reaction
+105916003,Phenothiazine derivative antipsychotic
+10784006,Medicinal product acting as antipsychotic agent
+108385001,Benzisoxazole derivative antipsychotic agent
+108439000,Phenylbutylpiperadine derivative antipsychotic agent
+10981006,Severe mixed bipolar I disorder with psychotic features
+111482003,Subchronic schizophrenia with acute exacerbations
+111483008,Catatonic schizophrenia in remission
+111484002,Undifferentiated schizophrenia
+121331001,Antipsychotic identification
+12939007,Chronic disorganized schizophrenia
+133091000119105,Rapid cycling bipolar I disorder
+13313007,Mild bipolar disorder
+13601005,Paranoid personality disorder
+13746004,Bipolar disorder
+14291003,Subchronic disorganized schizophrenia with acute exacerbations
+14495005,"Severe bipolar I disorder, single manic episode without psychotic features"
+154844001,Organic psychotic condition
+154865007,Schizophrenic psychoses (& [paranoid schizophrenia])
+154866008,Simple schizophrenia
+154867004,Hebephrenic schizophrenia
+154868009,Catatonic schizophrenia
+154869001,(Paranoid schizophrenia) or (paraphrenia)
+154870000,Schizophrenia NOS
+154871001,Affective psychoses: [manic depressive] or [involutional melancholia]
+162004,Severe manic bipolar I disorder without psychotic features
+16506000,Mixed bipolar I disorder
+16990005,Subchronic schizophrenia
+17435002,Chronic paranoid schizophrenia with acute exacerbations
+191447007,Organic psychotic condition
+191502008,"Acute confusional state, of infective origin"
+191525009,Non-organic psychosis
+191526005,Schizophrenic disorders
+191527001,Simple schizophrenia
+191528006,Unspecified schizophrenia
+191529003,Subchronic schizophrenia
+191530008,Acute exacerbation of subchronic schizophrenia
+191531007,Acute exacerbation of chronic schizophrenia
+191534004,Simple schizophrenia NOS
+191535003,Unspecified hebephrenic schizophrenia
+191536002,Subchronic hebephrenic schizophrenia
+191537006,Chronic hebephrenic schizophrenia
+191538001,Acute exacerbation of subchronic hebephrenic schizophrenia
+191539009,Acute exacerbation of chronic hebephrenic schizophrenia
+191540006,Hebephrenic schizophrenia in remission
+191541005,Hebephrenic schizophrenia NOS
+191542003,Catatonic schizophrenia
+191543008,Unspecified catatonic schizophrenia
+191544002,Subchronic catatonic schizophrenia
+191545001,Chronic catatonic schizophrenia
+191547009,Acute exacerbation of subchronic catatonic schizophrenia
+191548004,Acute exacerbation of chronic catatonic schizophrenia
+191550007,Catatonic schizophrenia NOS
+191551006,Unspecified paranoid schizophrenia
+191552004,Subchronic paranoid schizophrenia
+191553009,Chronic paranoid schizophrenia
+191554003,Acute exacerbation of subchronic paranoid schizophrenia
+191555002,Acute exacerbation of chronic paranoid schizophrenia
+191557005,Paranoid schizophrenia NOS
+191558000,Acute schizophrenic episode (& [oneirophrenia])
+191559008,Latent schizophrenia
+191560003,Unspecified latent schizophrenia
+191561004,Subchronic latent schizophrenia
+191562006,Chronic latent schizophrenia
+191563001,Acute exacerbation of subchronic latent schizophrenia
+191564007,Acute exacerbation of chronic latent schizophrenia
+191566009,Latent schizophrenia NOS
+191567000,Schizoaffective schizophrenia
+191568005,Unspecified schizoaffective schizophrenia
+191569002,Subchronic schizoaffective schizophrenia
+191570001,Chronic schizoaffective schizophrenia
+191571002,Acute exacerbation of subchronic schizoaffective schizophrenia
+191572009,Acute exacerbation of chronic schizoaffective schizophrenia
+191575006,Schizoaffective schizophrenia NOS
+191576007,Schizophrenia: [other] or [cenesthopathic]
+191577003,Cenesthopathic schizophrenia
+191578008,Other schizophrenia NOS
+191579000,Schizophrenia NOS
+191580002,Affective psychoses (& [bipolar] or [depressive] or [manic])
+191583000,"Single manic episode, mild"
+191584006,"Single manic episode, moderate"
+191586008,"Single manic episode, severe, with psychosis"
+191590005,Recurrent manic episodes
+191592002,"Recurrent manic episodes, mild"
+191593007,"Recurrent manic episodes, moderate"
+191595000,"Recurrent manic episodes, severe, with psychosis"
+191618007,"Bipolar affective disorder, current episode manic"
+191619004,"Bipolar affective disorder, currently manic, unspecified"
+191620005,"Bipolar affective disorder, currently manic, mild"
+191621009,"Bipolar affective disorder, currently manic, moderate"
+191622002,"Bipolar affective disorder, currently manic, severe, without mention of psychosis"
+191623007,"Bipolar affective disorder, currently manic, severe, with psychosis"
+191625000,"Bipolar affective disorder, currently manic, in full remission"
+191626004,"Bipolar affective disorder, currently manic, NOS"
+191627008,"Bipolar affective disorder, current episode depression"
+191628003,"Bipolar affective disorder, currently depressed, unspecified"
+191629006,"Bipolar affective disorder, currently depressed, mild"
+191630001,"Bipolar affective disorder, currently depressed, moderate"
+191631002,"Bipolar affective disorder, currently depressed, severe, without mention of psychosis"
+191632009,"Bipolar affective disorder, currently depressed, severe, with psychosis"
+191634005,"Bipolar affective disorder, currently depressed, in full remission"
+191635006,"Bipolar affective disorder, currently depressed, NOS"
+191636007,Mixed bipolar affective disorder
+191637003,"Mixed bipolar affective disorder, unspecified"
+191638008,"Mixed bipolar affective disorder, mild"
+191639000,"Mixed bipolar affective disorder, moderate"
+191640003,"Mixed bipolar affective disorder, severe, without mention of psychosis"
+191641004,"Mixed bipolar affective disorder, severe, with psychosis"
+191644007,"Mixed bipolar affective disorder, NOS"
+191646009,Unspecified bipolar affective disorder
+191647000,"Unspecified bipolar affective disorder, unspecified"
+191648005,"Unspecified bipolar affective disorder, mild"
+191649002,"Unspecified bipolar affective disorder, moderate"
+191650002,"Unspecified bipolar affective disorder, severe, without mention of psychosis"
+191651003,"Unspecified bipolar affective disorder, severe, with psychosis"
+191654006,"Unspecified bipolar affective disorder, NOS"
+191658009,Atypical manic disorder
+191659001,Atypical depressive disorder
+191664002,Rebound mood swings
+191667009,Paranoid disorder
+191668004,Simple paranoid state
+191670008,Shared paranoid disorder
+191672000,Paranoia querulans
+191676002,Reactive depressive psychosis
+191677006,Acute hysterical psychosis
+191678001,Reactive confusion
+191680007,Psychogenic paranoid psychosis
+191683009,Psychogenic stupor
+191686001,Psychosis: [nonorganic NOS] or [episode NOS]
+191687005,Psychosis with origin in childhood
+191692007,Active disintegrative psychoses
+191693002,Residual disintegrative psychoses
+192190003,[X] (Organic delusional (schizophrenia-like) disorder) or (paranoid organic state) or (schizophrenia-like psychosis in epilepsy)
+192318004,"[X]Schizophrenia, schizotypal and delusional disorders"
+192319007,Paranoid schizophrenia
+192320001,Hebephrenic schizophrenia
+192321002,[X] (Catatonic schizophrenia) or (catatonic stupor) or (schizophrenic catalepsy) or (schizophrenic catatonia) or (schizophrenic flexibilatis cerea)
+192322009,[X]Undifferentiated schizophrenia
+192323004,Post-schizophrenic depression
+192324005,Residual schizophrenia
+192325006,Simple schizophrenia
+192326007,[X] (Schizophrenia: [cenesthopathic] or [other]) or (schizophreniform disorder [including psychosis] NOS)
+192327003,"[X]Schizophrenia, unspecified"
+192328008,[X] Schizotypal disorder (& [latent] or [latent schizophrenic reaction] or [borderline] or [prepsychotic] or [prodromal] or [pseudoneurotic] or [pseudopsychopathic]
+192333007,Acute transient psychotic disorder
+192334001,[X] Acute polymorphic psychotic disorder without symptoms of schizophrenia (& [bouffee delirante] or [cycloid psychosis])
+192335000,[X]Acute polymorphic psychotic disorder with symptoms of schizophrenia
+192336004,[X] Acute schizophrenia-like psychotic disorder (& [brief schizophreniform disorder] or [brief schizophrenifrm psych] or [oneirophrenia] or [schizophrenic reaction])
+192338003,[X] (Other acute predominantly delusional psychotic disorders) or (psychogenic paranoid psychosis)
+192339006,[X]Other acute and transient psychotic disorders
+192340008,"[X]Acute and transient psychotic disorder, unspecified (& [reactive psychosis (including brief NOS)])"
+192343005,"[X](Schizoaffective disorder, mixed type) or (cyclic schizophrenia) or (mixed schizophrenic and affective psychosis)"
+192346002,[X] (Other nonorganic psychotic disorders) or
+192349009,"[X] Manic episode (& [bipolar disorder, single manic episode])"
+192351008,[X]Mania without psychotic symptoms
+192352001,[X] (Mania with psychotic symptoms (& mood [congruent] or [incongruent])) or (manic stupor)
+192355004,Bipolar disorder
+192356003,"[X]Bipolar affective disorder, current episode manic without psychotic symptoms"
+192357007,"[X]Bipolar affective disorder, current episode manic with psychotic symptoms"
+192358002,"[X]Bipolar affective disorder, current episode mild or moderate depression"
+192359005,"[X]Bipolar affective disorder, current episode severe depression without psychotic symptoms"
+192361001,"Bipolar affective disorder, currently depressed, severe, with psychosis"
+192362008,"Bipolar affective disorder, current episode mixed"
+192364009,[X] (Bipolar affective disorders: [bipolar II] or [other]) or (recurrent manic episodes)
+192365005,"[X]Bipolar affective disorder, unspecified"
+192370003,[X] Severe depressive episode with psychotic symptoms: (& single episode of [major depression] or [psychogenic depressive psychosis] or [psychotic depression] or [reactive depressive psychosis])
+192377000,"[X]Depression without psychotic symptoms: [recurrent: [major] or [manic-depressive psychosis, depressed type] or [vital] or [current severe episode]] or [endogenous]"
+192378005,"[X] Depression with psychotic symptoms: [recurrent: (current episode severe) or (manic-depressive, depressed type) or (severe major episodes) or (severe episodes)] or [endogenous]"
+2073000,Delusions
+21071000119101,Mood disorder of manic type
+216004,Delusion of persecution
+21894002,Chronic catatonic schizophrenia with acute exacerbations
+223043001,[X]Phenothiazine antipsychotics and neuroleptics causing adverse effects in therapeutic use
+223045008,[X]Other antipsychotics and neuroleptics causing adverse effects in therapeutic use
+225452001,Paranoid delusion
+231436002,Psychotic episode NOS
+231437006,Reactive psychoses
+231483000,Psychotic disorder
+231485007,Post-schizophrenic depression
+231487004,Persistent delusional disorder
+231489001,Acute transient psychotic disorder
+231494001,Mania
+231495000,Manic stupor
+231496004,Hypomania
+231497008,Bipolar II disorder
+231500002,Masked depression
+247667002,Grandiose delusions
+247804008,Schizophrenic prodrome
+26025008,Residual schizophrenia
+26472000,Paraphrenia
+26516009,Severe mood disorder with psychotic features
+26530004,"Severe bipolar disorder with psychotic features, mood-incongruent"
+26847009,Chronic schizophrenia with acute exacerbations
+268514004,On lithium
+268617001,Acute schizophrenic episode
+268618006,Other schizophrenia
+268619003,"Manic disorder, single episode"
+268622001,Chronic paranoid psychosis
+268624000,Acute paranoid reaction
+268691004,[X]Other schizophrenia
+268694007,[X]Acute polymorphic psychotic disorder without symptoms of schizophrenia
+268695008,[X]Other acute predominantly delusional psychotic disorders
+268696009,"[X]Acute and transient psychotic disorder, unspecified"
+268697000,[X]Other non-organic psychotic disorders
+268699002,[X]Mania with psychotic symptoms
+268701002,[X]Other bipolar affective disorders
+268704005,[X]Severe depressive episode with psychotic symptoms
+268708008,"[X]Recurrent depressive disorder, current episode severe without psychotic symptoms"
+268709000,"[X]Recurrent depressive disorder, current episode severe with psychotic symptoms"
+268747005,Schizophrenic psychoses (& [paranoid schizophrenia])
+268748000,(Paranoid schizophrenia) or (paraphrenia)
+268749008,Affective psychoses: [manic depressive] or [involutional melancholia]
+268958005,Poor insight into neurotic condition
+270901009,"Schizoaffective disorder, mixed type"
+271428004,"Schizoaffective disorder, manic type"
+27387000,Subchronic disorganized schizophrenia
+274952002,Borderline schizophrenia
+275917000,Lithium monitoring
+278853003,Acute schizophrenia-like psychotic disorder
+280427006,Psychotic symptom present
+28663008,Severe manic bipolar I disorder with psychotic features
+286682001,Psychotic denial - mental defense mechanism
+304757008,"Profile of mood states, bipolar"
+30520009,"Severe bipolar II disorder, most recent episode major depressive with psychotic features"
+307417003,Cycloid psychosis
+307504004,Oneirophrenia
+31025003,Dibenzoxazepine derivative antipsychotic agent
+31027006,Schizotypal personality disorder
+310462009,"[X] Manic-depressive psychosis, depressed type without psychotic symptoms"
+31373002,Disorganized schizophrenia in remission
+31446002,"Bipolar I disorder, most recent episode hypomanic"
+31658008,Chronic paranoid schizophrenia
+321415008,Haloperidol [antipsychotic]
+321537004,Trifluoperazine [antipsychotic]
+321648000,Antipsychotic depot injections
+3298001,Amnestic disorder
+345021000000108,Enabling patient to integrate psychotic symptoms into holistic self
+349871006,Antipsychotic drug
+35252006,Disorganized schizophrenia
+35489007,Depressive disorder
+357705009,Cotard's syndrome
+358924003,Atypical antipsychotic
+35919005,Pervasive developmental disorder
+363895008,Psychotic symptom
+36474008,Severe recurrent major depression without psychotic features
+365431009,Finding of level of psychoticism
+36940000,Thioxanthene derivative antipsychotic agent
+371596008,Bipolar I disorder
+371600003,Severe bipolar disorder
+372482001,Anti-psychotic agent
+372483006,Benzisoxazole derivative antipsychotic agent
+372492009,Phenylbutylpiperadine derivative antipsychotic agent
+372648004,Atypical antipsychotic
+372696004,Dibenzoxazepine derivative antipsychotic agent
+372808009,Butyrophenone derivative antipsychotic agent
+373207000,Phenothiazine derivative antipsychotic agent
+373255000,Thioxanthene derivative antipsychotic agent
+373257008,Diphenylbutylpiperidine derivative antipsychotic agent
+373264005,Dihydroindolone derivative antipsychotic agent
+37773009,Diphenylbutylpiperidine derivative antipsychotic agent
+38295006,Involutional paraphrenia
+38368003,"Schizoaffective disorder, bipolar type"
+386256003,Delusion management
+387095003,Lithium carbonate
+387098001,Lithium citrate
+395771006,Lithium succinate
+397711000000100,[X]Severe depressive episode with psychotic symptoms
+401681000000101,[X]Mania with psychotic symptoms
+401761000000100,[X] Severe depressive episode with psychotic symptoms: (& single episode of [major depression] or [psychogenic depressive psychosis] or [psychotic depression] or [reactive depressive psychosis])
+402441000000102,"[X]Recurrent depressive disorder, current episode severe without psychotic symptoms"
+405273008,Manic mood
+406782009,Dihydrocarbostyril derivative antipsychotic
+406783004,Dihydrocarbostyril derivative antipsychotic agent
+408490001,Antipsychotic drug therapy
+40926005,Moderate mixed bipolar I disorder
+409380004,Benzimidazolinone derivative antipsychotic preparation
+409381000,Benzimidazolinone derivative antipsychotic agent
+41189006,Ideas of reference
+413991000000106,[X] (Other acute predominantly delusional psychotic disorders) or (psychogenic paranoid psychosis)
+41521002,Subchronic paranoid schizophrenia with acute exacerbations
+416340002,Late onset schizophrenia
+416611006,On examination - paranoid delusions
+416890005,On examination - delusion of persecution
+417233008,Paranoid ideation
+417601000000102,"[X]Schizophrenia, schizotypal and delusional disorders"
+417731000000103,"[X]Bipolar affective disorder, unspecified"
+41832009,"Severe bipolar I disorder, single manic episode with psychotic features"
+418931000000101,[X] Acute polymorphic psychotic disorder without symptoms of schizophrenia (& [bouffee delirante] or [cycloid psychosis])
+419271000000100,[X] (Bipolar affective disorders: [bipolar II] or [other]) or (recurrent manic episodes)
+426091000000108,[X]Other bipolar affective disorders
+426321000000107,[X]Other schizophrenia
+427834006,Benzamide derivative antipsychotic agent
+428091000000109,[X]Mania without psychotic symptoms
+428096005,Benzamide derivative antipsychotic agent
+42868002,Subchronic catatonic schizophrenia
+431661000000104,"[X]Bipolar affective disorder, current episode manic with psychotic symptoms"
+435581000000109,[X]Phenothiazine antipsychotics and neuroleptics causing adverse effects in therapeutic use
+43769008,Mild mixed bipolar I disorder
+4390004,Lithium nephropathy
+440701009,Injection of depot antipsychotic agent
+441704009,Affective psychosis
+442251000000107,[X]Undifferentiated schizophrenia
+442891000000100,[X]Acute polymorphic psychotic disorder with symptoms of schizophrenia
+443561000000100,"[X]Bipolar affective disorder, current episode manic without psychotic symptoms"
+443791000000100,[X] Schizotypal disorder (& [latent] or [latent schizophrenic reaction] or [borderline] or [prepsychotic] or [prodromal] or [pseudoneurotic] or [pseudopsychopathic]
+444051000000108,"[X]Recurrent depressive disorder, current episode severe with psychotic symptoms"
+4441000,Severe bipolar disorder with psychotic features
+446471000000103,[X]Other antipsychotics and neuroleptics causing adverse effects in therapeutic use
+44906001,Capgras' syndrome
+452061000000102,[X]Acute polymorphic psychotic disorder without symptoms of schizophrenia
+455161000000109,[X]Other non-organic psychotic disorders
+46206005,Mood disorder
+46229002,Severe mixed bipolar I disorder without psychotic features
+465911000000102,"[X]Bipolar affective disorder, current episode severe depression without psychotic symptoms"
+466791000000100,"[X]Acute and transient psychotic disorder, unspecified"
+467121000000100,"[X]Bipolar affective disorder, current episode mild or moderate depression"
+467361000000105,"[X] Manic-depressive psychosis, depressed type without psychotic symptoms"
+467591000000109,[X] (Mania with psychotic symptoms (& mood [congruent] or [incongruent])) or (manic stupor)
+470301000000100,"[X]Schizophrenia, unspecified"
+470311000000103,[X]Other acute and transient psychotic disorders
+470741000000103,[X] (Schizophrenia: [cenesthopathic] or [other]) or (schizophreniform disorder [including psychosis] NOS)
+473452003,Atypical psychosis
+479991000000101,[X]Other acute predominantly delusional psychotic disorders
+480111000000107,[X] (Other nonorganic psychotic disorders) or
+48500005,Delusional disorder
+48937005,"Bipolar II disorder, most recent episode hypomanic"
+49468007,Depressed bipolar I disorder
+507861000000107,Severe major depression with psychotic features
+509791000000101,Severe major depression with psychotic features
+52451004,Dihydroindolone derivative antipsychotic agent
+52954000,Schizoid personality disorder
+529851000000108,"Mixed bipolar affective disorder, severe, without mention of psychosis"
+530301000000105,"Bipolar affective disorder, currently manic, severe, without mention of psychosis"
+530311000000107,"Bipolar affective disorder, currently depressed, severe, without mention of psychosis"
+53049002,Severe bipolar disorder without psychotic features
+5464005,Brief reactive psychosis
+5510009,Organic delusional disorder
+551591000000100,Unspecified puerperal psychosis
+558801000000101,Other schizophrenia
+579811000000105,Paranoid schizophrenia NOS
+579821000000104,Unspecified latent schizophrenia
+58214004,Schizophrenia
+58647003,"Severe mood disorder with psychotic features, mood-congruent"
+589301000000108,Other transient organic psychoses
+589311000000105,Other chronic organic psychoses
+589331000000102,Unspecified schizophrenia
+589341000000106,Simple schizophrenia NOS
+589351000000109,Hebephrenic schizophrenia NOS
+589361000000107,Unspecified catatonic schizophrenia
+589371000000100,Latent schizophrenia NOS
+589381000000103,Unspecified schizoaffective schizophrenia
+59617007,Severe depressed bipolar I disorder with psychotic features
+602481000000108,"Mixed bipolar affective disorder, NOS"
+602491000000105,Unspecified bipolar affective disorder
+602511000000102,"Unspecified bipolar affective disorder, unspecified"
+602521000000108,"Unspecified bipolar affective disorder, mild"
+602531000000105,"Unspecified bipolar affective disorder, moderate"
+602541000000101,"Unspecified bipolar affective disorder, severe, with psychosis"
+613511000000109,"Bipolar affective disorder, currently depressed, NOS"
+613581000000102,"Mixed bipolar affective disorder, unspecified"
+613611000000108,"Unspecified bipolar affective disorder, severe, without mention of psychosis"
+61403008,Severe depressed bipolar I disorder without psychotic features
+615931000000107,"Bipolar affective disorder, currently manic, NOS"
+615941000000103,"Bipolar affective disorder, currently depressed, unspecified"
+61771000119106,"Bipolar II disorder, most recent episode rapid cycling"
+61831009,Induced psychotic disorder
+623971000000101,"Unspecified bipolar affective disorder, NOS"
+63181006,Paranoid schizophrenia in remission
+632271000000100,Psychotic episode NOS
+633351000000106,Unspecified hebephrenic schizophrenia
+633391000000103,Catatonic schizophrenia NOS
+633401000000100,Unspecified paranoid schizophrenia
+633731000000103,"Bipolar affective disorder, currently manic, unspecified"
+645431000000108,Schizoaffective schizophrenia NOS
+645441000000104,Other schizophrenia NOS
+645451000000101,Schizophrenia NOS
+64905009,Paranoid schizophrenia
+6517004,Butyrophenone derivative antipsychotic agent
+67002003,"Severe bipolar II disorder, most recent episode major depressive, in partial remission"
+68569003,Manic bipolar I disorder
+68890003,Schizoaffective disorder
+68995007,Chronic catatonic schizophrenia
+69322001,Psychotic disorder
+69482004,Korsakoff's psychosis
+703257008,Assessment of cause of psychotic and behavioral symptoms
+70546001,"Severe bipolar disorder with psychotic features, mood-congruent"
+712824002,Acute polymorphic psychotic disorder without symptoms of schizophrenia
+712850003,Acute polymorphic psychotic disorder co-occurrent with symptoms of schizophrenia
+718024008,Oral antipsychotic therapy
+718026005,Cognitive behavioral therapy for psychosis
+71961003,Childhood disintegrative disorder
+719788008,On combination antipsychotic drug therapy
+720409006,High dose antipsychotic drug therapy
+724755002,Positive symptoms co-occurrent and due to primary psychotic disorder
+724756001,Negative symptoms co-occurrent and due to primary psychotic disorder
+724757005,Depressive symptoms due to primary psychotic disorder
+724758000,Manic symptoms co-occurrent and due to primary psychotic disorder
+724759008,Psychomotor symptom co-occurrent and due to psychotic disorder
+724760003,Cognitive impairment co-occurrent and due to primary psychotic disorder
+755361000000103,Lithium level checked at 3 monthly intervals
+756471000000108,Lithium therapy record book completed
+760721000000109,"Mixed bipolar affective disorder, in partial remission"
+76105009,Cyclothymia
+764591000000108,"Mixed bipolar affective disorder, severe"
+764621000000106,"Recurrent manic episodes, severe"
+764641000000104,"Single manic episode, severe"
+764731000000103,Single manic episode in partial remission
+765176007,Psychosis and severe depression co-occurrent and due to bipolar affective disorder
+767631007,"Bipolar disorder, most recent episode depression"
+767632000,"Bipolar disorder, most recent episode manic"
+767633005,"Bipolar affective disorder, most recent episode mixed"
+76839006,Catatonic schizophrenia
+769063007,Antipsychotic medication review
+773883000,Antipsychotic therapeutic role
+782461000000107,Antipsychotic medication review
+782471000000100,Antipsychotic medication review 
+789061003,Rapid cycling bipolar II disorder
+790711000000100,Bipolar I disorder
+79584002,Moderate bipolar disorder
+79866005,Subchronic paranoid schizophrenia
+808681000000102,Bipolar I disorder
+808691000000100,Bipolar II disorder
+81319007,"Severe bipolar II disorder, most recent episode major depressive without psychotic features"
+83225003,Bipolar II disorder
+83746006,Chronic schizophrenia
+84760002,"Schizoaffective disorder, depressive type"
+86817004,Subchronic catatonic schizophrenia with acute exacerbations
+87950005,"Bipolar I disorder, single manic episode with catatonic features"
+885271000000107,Antipsychotic medication physical health check
+885281000000109,Antipsychotic medication physical health check 
+886451000000108,Assessment of cause of psychotic and behavioural symptoms
+886461000000106,Assessment of cause of psychotic behavioural symptoms 
+88939009,Severe mood disorder without psychotic features
+88975006,Schizophreniform disorder
+9340000,"Bipolar I disorder, single manic episode"
+984401000000108,Oral antipsychotic therapy
+984411000000105,Oral antipsychotic therapy 
+998601000000104,Urine lithium concentration

--- a/codelists/user-hjforbes-suicide-icd-10.csv
+++ b/codelists/user-hjforbes-suicide-icd-10.csv
@@ -1,0 +1,51 @@
+code,term
+X60,"Intentional self-poisoning by and exposure to nonopioid analgesics, antipyretics and antirheumatics"
+X61,"Intentional self-poisoning by and exposure to antiepileptic, sedative-hypnotic, antiparkinsonism and psychotropic drugs, not elsewhere classified"
+X62,"Intentional self-poisoning by and exposure to narcotics and psychodysleptics [hallucinogens], not elsewhere classified"
+X63,Intentional self-poisoning by and exposure to other drugs acting on the autonomic nervous system
+X64,"Intentional self-poisoning by and exposure to other and unspecified drugs, medicaments and biological substances"
+X65,Intentional self-poisoning by and exposure to alcohol
+X66,Intentional self-poisoning by and exposure to organic solvents and halogenated hydrocarbons and their vapours
+X67,Intentional self-poisoning by and exposure to carbon monoxide and other gases and vapours
+X68,Intentional self-poisoning by and exposure to pesticides
+X69,Intentional self-poisoning by and exposure to other and unspecified chemicals and noxious substances
+X70,"Intentional self-harm by hanging, strangulation and suffocation"
+X71,Intentional self-harm by drowning and submersion
+X72,Intentional self-harm by handgun discharge
+X73,"Intentional self-harm by rifle, shotgun and larger firearm discharge"
+X74,Intentional self-harm by other and unspecified firearm discharge
+X75,Intentional self-harm by explosive material
+X76,"Intentional self-harm by smoke, fire and flames"
+X77,"Intentional self-harm by steam, hot vapours and hot objects"
+X78,Intentional self-harm by sharp object
+X79,Intentional self-harm by blunt object
+X80,Intentional self-harm by jumping from a high place
+X81,Intentional self-harm by jumping or lying before moving object
+X82,Intentional self-harm by crashing of motor vehicle
+X83,Intentional self-harm by other specified means
+X84,Intentional self-harm by unspecified means
+Y10,"Poisoning by and exposure to nonopioid analgesics, antipyretics and antirheumatics, undetermined intent"
+Y11,"Poisoning by and exposure to antiepileptic, sedative-hypnotic, antiparkinsonism and psychotropic drugs, not elsewhere classified, undetermined intent"
+Y12,"Poisoning by and exposure to narcotics and psychodysleptics [hallucinogens], not elsewhere classified, undetermined intent"
+Y13,"Poisoning by and exposure to other drugs acting on the autonomic nervous system, undetermined intent"
+Y14,"Poisoning by and exposure to other and unspecified drugs, medicaments and biological substances, undetermined intent"
+Y15,"Poisoning by and exposure to alcohol, undetermined intent"
+Y16,"Poisoning by and exposure to organic solvents and halogenated hydrocarbons and their vapours, undetermined intent"
+Y17,"Poisoning by and exposure to carbon monoxide and other gases and vapours, undetermined intent"
+Y18,"Poisoning by and exposure to pesticides, undetermined intent"
+Y19,"Poisoning by and exposure to other and unspecified chemicals and noxious substances, undetermined intent"
+Y20,"Hanging, strangulation and suffocation, undetermined intent"
+Y21,"Drowning and submersion, undetermined intent"
+Y22,"Handgun discharge, undetermined intent"
+Y23,"Rifle, shotgun and larger firearm discharge, undetermined intent"
+Y24,"Other and unspecified firearm discharge, undetermined intent"
+Y25,"Contact with explosive material, undetermined intent"
+Y26,"Exposure to smoke, fire and flames, undetermined intent"
+Y27,"Contact with steam, hot vapours and hot objects, undetermined intent"
+Y28,"Contact with sharp object, undetermined intent"
+Y29,"Contact with blunt object, undetermined intent"
+Y30,"Falling, jumping or pushed from a high place, undetermined intent"
+Y31,"Falling, lying or running before or into moving object, undetermined intent"
+Y32,"Crashing of motor vehicle, undetermined intent"
+Y33,"Other specified events, undetermined intent"
+Y34,"Unspecified event, undetermined intent"


### PR DESCRIPTION
For 'Depression', 'Anxiety - general', 'Anxiety - obsessive compulsive disorder', 'Anxiety - post traumatic stress disorder', 'Eating disorders', 'Serious mental illness', 'Self harm', 'Suicide', 'Addiction':

- Add outcomes that contain the first date of a relevant code after index
- Add covariates that contain a binary flag for ever had a code prior to index