### PR TITLE
Overwrite patient IDs to retain more of the sample

### DIFF
--- a/analysis/preprocess_data.R
+++ b/analysis/preprocess_data.R
@@ -20,6 +20,12 @@ for (i in c("index","vaccinated","electively_unvaccinated")) {
   
   tmp <- arrow::read_feather(file = paste0("output/input_",i,".feather"))
   
+  # Overwrite patient IDs for dummy data only ----------------------------------
+  
+  if(Sys.getenv("OPENSAFELY_BACKEND") %in% c("", "expectations")) {
+    tmp$patient_id <- df$patient_id
+  }
+  
   ## Identify dynamic variables in dataset
   
   keep <- c("patient_id",


### PR DESCRIPTION
Patient IDs are randomly sampled for each study definition. Originally we were relying on there being common IDs among the three study definitions. This immediately reduced our sample from 500,000 to ~5,000 before preprocessing. After preprocessing, we had a sample of ~2,000 in each cohort. 

This PR adds code to overwrite the patient IDs in all study definitions to be the patient IDs from input_index.feather when using the dummy data. This means that, after preprocessing, we now have a sample of ~200,000 in each cohort. After stage 1, we have samples of ~35,000 for the vaccinated cohort and ~54,000 for the electively unvaccinated cohort.