### PR TITLE
Update factors to be unordered by default

### DIFF
--- a/analysis/Stage1_data_cleaning.R
+++ b/analysis/Stage1_data_cleaning.R
@@ -99,7 +99,7 @@ stage1 <- function(cohort_name){
     covars[,cat_factors] <- lapply(covars[,cat_factors], function(x) factor(x, ordered = FALSE))
     
     ## sub_cat_covid19_hospital
-    covars$sub_cat_covid19_hospital <- ordered(covars$sub_cat_covid19_hospital, levels = c("no_infection","non_hospitalised","hospitalised"))
+    covars$sub_cat_covid19_hospital <- ordered(covars$sub_cat_covid19_hospital, levels = c("non_hospitalised","hospitalised","no_infection"))
   
     ## cov_cat_ethnicity
     levels(covars$cov_cat_ethnicity) <- list("Missing" = "0", "White" = "1", "Mixed" = "2", "South Asian" = "3", "Black" = "4", "Other" = "5")


### PR DESCRIPTION
- Update factor code so factors are unordered by default - this allows relevel() to be used as it cannot handle ordered factors
- Specified reference categories for categorical variables - these are variables we expect to be included in almost all analyses so not too too bad in terms of pipeline generalisability
- Made FALSE the reference category for all binary variables