### PR TITLE
Add 'main' column to specify whether to run main analysis

### DIFF
--- a/analysis/active_analyses.R
+++ b/analysis/active_analyses.R
@@ -6,6 +6,7 @@ df <- data.frame(active = logical(),
                  covariates = character(),
                  model = character(),
                  cohort	= character(),
+                 main = character(),
                  covid_history = character(),
                  covid_pheno_hospitalised = character(),
                  covid_pheno_non_hospitalised = character(),
@@ -45,7 +46,7 @@ for (i in 1:length(outcomes)) {
                        paste0("out_date_",outcomes_short[i]),
                        "cov_num_consulation_rate;cov_bin_healthcare_worker;cov_num_age;cov_cat_ethnicity;cov_cat_deprivation;cov_cat_region;cov_cat_smoking_status;cov_bin_carehome_status;cov_bin_lipid_medications;cov_bin_antiplatelet_medications;cov_bin_anticoagulation_medications;cov_bin_combined_oral_contraceptive_pill;cov_bin_hormone_replacement_therapy;cov_bin_ami;cov_bin_all_stroke;cov_bin_other_arterial_embolism;cov_bin_vte;cov_bin_hf;cov_bin_angina;cov_bin_dementia;cov_bin_liver_disease;cov_bin_chronic_kidney_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_obesity;cov_bin_depression;cov_bin_chronic_obstructive_pulmonary_disease;cov_cat_sex",
                        rep("all",2),
-                       rep(TRUE,3),
+                       rep(TRUE,4),
                        rep(FALSE,14),
                        "")
 }
@@ -62,7 +63,7 @@ for (i in 1:length(outcomes)) {
                        paste0("out_date_",outcomes_short[i]),
                        "cov_num_consulation_rate;cov_bin_healthcare_worker;cov_num_age;cov_cat_ethnicity;cov_cat_deprivation;cov_cat_region;cov_cat_smoking_status;cov_bin_carehome_status;cov_bin_lipid_medications;cov_bin_antiplatelet_medications;cov_bin_anticoagulation_medications;cov_bin_combined_oral_contraceptive_pill;cov_bin_hormone_replacement_therapy;cov_bin_ami;cov_bin_all_stroke;cov_bin_other_arterial_embolism;cov_bin_vte;cov_bin_hf;cov_bin_angina;cov_bin_dementia;cov_bin_liver_disease;cov_bin_chronic_kidney_disease;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_obesity;cov_bin_depression;cov_bin_chronic_obstructive_pulmonary_disease;cov_cat_sex",
                        rep("all",2),
-                       rep(TRUE,17),
+                       rep(TRUE,18),
                        "")
 }
 
@@ -82,7 +83,7 @@ for (i in 1:length(outcomes)) {
   df[nrow(df)+1,] <- c(FALSE,
                        outcomes[i],
                        paste0("out_date_",outcomes_short[i]),
-                       rep("",21))
+                       rep("",22))
 }
 
 # Add diabetes outcomes --------------------------------------------------------
@@ -113,7 +114,7 @@ for (i in 1:length(outcomes)) {
   df[nrow(df)+1,] <- c(FALSE,
                        outcomes[i],
                        paste0("out_date_",outcomes_short[i]),
-                       rep("",21))
+                       rep("",22))
 }
 
 # Save active analyses list ----------------------------------------------------


### PR DESCRIPTION
Add 'main' column to active analyses table so that we can specify in different columns whether to run the main analysis (which excludes people with covid history) or to run the subgroup analysis for those with a history of covid.