### PR TITLE
fix error in prostate cancer code

### DIFF
--- a/analysis/codelists.py
+++ b/analysis/codelists.py
@@ -430,7 +430,7 @@ angina_icd10 = codelist_from_csv(
 )
 
 prostate_cancer_icd10 = codelist_from_csv(
-    "codelists/user-RochelleKnight-prostate_cancer_snomed.csv",
+    "codelists/user-RochelleKnight-prostate_cancer_icd10.csv",
     system="icd10",
     column="code",
 )


### PR DESCRIPTION
I discovered an error in the codelist.py file. The prostate cancer ICD 10 variable was calling the snomed codelist. This PR amends this. 