### PR TITLE
Supplementary table 1 main analysis

### DIFF
--- a/analysis/Supplementary_table_1_CVD.R
+++ b/analysis/Supplementary_table_1_CVD.R
@@ -10,7 +10,7 @@ library(markdown)
 #Intention is to run outside of opensafely environment?
 
 #-----------------------Determine active outcome events-------------------------
-active_analyses <- read_rds("output/active_analyses.rds")
+active_analyses <- read_rds("lib/active_analyses.rds")
 events <- active_analyses %>% filter(active=="TRUE")%>%select(outcome,outcome_variable)
 events$outcome_variable <- gsub("out_date_","",events$outcome_variable)
 
@@ -32,19 +32,14 @@ combined_hr <- rbindlist(hr_file_paths, fill=TRUE)
 combined_hr <- combined_hr %>% filter(event %in% events$outcome_variable)
 combined_hr <- combined_hr %>% filter(!event %in% c("ate","vte"))
 combined_hr <- combined_hr %>% filter(subgroup %in% c("main","covid_pheno_hospitalised","covid_pheno_non_hospitalised","covid_history"))
-#combined_hr$type <- "Hazard ratio"
-#combined_event_counts <- combined_hr %>% select(expo_week,events_total,event,subgroup,model,cohort)
-#combined_event_counts$type <- "Event count"
 
 #---------Select relevant 'term' rows for post-COVID time periods---------------
 
 combined_hr <- combined_hr %>% filter(str_detect(term, "^days"))
-#combined_event_counts <- combined_event_counts %>% filter(!is.na(expo_week) & str_detect(expo_week, "^days"))
 
 # Make names 'nice' ----------------------------------------------------------
 
 combined_hr <- combined_hr %>% left_join(events, by=c("event"="outcome_variable"))
-#combined_event_counts <- combined_event_counts %>% left_join(events, by=c("event"="outcome_variable"))
 
 df=list(combined_hr)
 #df=list(combined_hr,combined_event_counts)
@@ -74,15 +69,10 @@ combined_hr$est <- paste0(ifelse(combined_hr$estimate>=10,sprintf("%.1f",combine
 
 # Remove unnecessary variables -----------------------------------------------
 combined_hr <- combined_hr %>% select(term,outcome,tidy_subgroup,est,model,cohort)
-#combined_event_counts <- combined_event_counts %>% select(outcome, expo_week, events_total, tidy_subgroup,model,cohort,type)
 
 # Convert long to wide -------------------------------------------------------
 
 combined_hr <- tidyr::pivot_wider(combined_hr, names_from = term, values_from = est)
-#combined_event_counts <- tidyr::pivot_wider(combined_event_counts, names_from = expo_week, values_from = events_total)
-
-# Combine hazard ratios and event counts ---------------------------------------
-#combined_hr_counts <- rbind(combined_hr,combined_event_counts)
 
 # Specify column order ---------------------------------------------------------
 #if(length(colnames(combined_hr_counts)[grepl("^days",colnames(combined_hr_counts))]) ==5){
@@ -104,8 +94,6 @@ combined_hr$tidy_subgroup <- factor(combined_hr$tidy_subgroup, levels=c("All",
                                                                       "Prior history of COVID-19",
                                                                       "Prior history of COVID-19, age/sex adjusted")) 
 
-#combined_hr$type <- factor(combined_hr$type, levels = c("Hazard ratio",
-#                                                          "Event count"))
 
 combined_hr$cohort <- factor(combined_hr$cohort, levels = c("vaccinated",
                                                             "electively_unvaccinated"))
@@ -125,13 +113,4 @@ for(i in c("vaccinated","electively_unvaccinated")){
   df=combined_hr %>% filter(cohort ==i)
   write_csv(df,paste0("output/supplementary_table_1_",i,".csv")) 
 }
-
-
-#write_csv(df,paste0("output/less_than_5_events_supplementary_table_1.csv")) 
-
-# Save a html of the results for easy reading in Level 4 server-----------------
-
-#rmarkdown::render("analysis/supplementary_table_1.Rmd",output_file="supplementary_table_1",output_dir="output")
-#rmarkdown::render("analysis/less_than_5_events_supplementary_table_1.Rmd",output_file="less_than_5_events_supplementary_table_1",output_dir="output")
-
 


### PR DESCRIPTION
This script creates supplementary table 1 which has the results from the main analysis, covid phenotype analysis and covid history sensitivity analysis. I think it is likely that this script will be updated once we have results and make more decisions about the format of the results etc.