### PR TITLE
remove covars that have been removed in previous function

### DIFF
--- a/analysis/fit_model.R
+++ b/analysis/fit_model.R
@@ -77,7 +77,8 @@ coxfit <- function(data_surv, interval_names, covar_names, subgroup, mdl){
   if(mdl=="mdl_agesex"){
     print(covariate_exploration(data_surv, c()))
   }else{
-    print(covariate_exploration(data_surv, append(covar_names,"ethnicity")))
+    covars_to_print <- covar_names[!covar_names %in% covars_to_remove]
+    print(covariate_exploration(data_surv, append(covars_to_print,"ethnicity")))
   }
 
   covariates <- covar_names[covar_names %in% names(data_surv)] %>% sort()


### PR DESCRIPTION
covariate_exploration splits the data by the covariates but need to remove the covars that were removed in previous step (can't subset columns that don't exist as removed)