### PR TITLE
Cox updates

### DIFF
--- a/analysis/format_tbls_HRs.R
+++ b/analysis/format_tbls_HRs.R
@@ -174,7 +174,7 @@ if(length(results_done)>0){
   combined_hr_event_counts=df_hr%>%left_join(event_counts_to_left_join, by=c("term","event","subgroup","cohort","model"))
   
   combined_hr_event_counts=combined_hr_event_counts%>%select(term,estimate,conf.low,conf.high,std.error,robust.se,P,expo_week,events_total,
-                                                             event,subgroup,model,cohort,covariates_removed,cat_covars_collapsed,total_covid19_cases)
+                                                             event,subgroup,model,cohort,total_covid19_cases)
   
   # Add in suppression for counts <=5
   combined_hr_event_counts$redacted_results <- "NA"


### PR DESCRIPTION
Removes the columns for the covariates removed/merged as these are based on counts <=2 so opensafely won't allow us to output these columns