### PR TITLE
add only confirmed covid icd10 code

### DIFF
--- a/analysis/codelists.py
+++ b/analysis/codelists.py
@@ -1,9 +1,9 @@
 from cohortextractor import codelist_from_csv, combine_codelists, codelist
 
 covid_codes = codelist_from_csv(
-    "codelists/opensafely-covid-identification.csv",
+    "codelists/user-RochelleKnight-confirmed-hospitalised-covid-19.csv",
     system="icd10",
-    column="icd10_code",
+    column="code",
 )
 
 covid_primary_care_positive_test = codelist_from_csv(
@@ -22,12 +22,6 @@ covid_primary_care_sequalae = codelist_from_csv(
     "codelists/opensafely-covid-identification-in-primary-care-probable-covid-sequelae.csv",
     system="ctv3",
     column="CTV3ID",
-)
-
-covid_codes = codelist_from_csv(
-    "codelists/opensafely-covid-identification.csv",
-    system="icd10",
-    column="icd10_code",
 )
 
 covid_primary_care_positive_test = codelist_from_csv(

--- a/codelists/codelists.json
+++ b/codelists/codelists.json
@@ -977,6 +977,12 @@
       "url": "https://codelists.opensafely.org/codelist/bristol/pe_i269/4e1aa651/",
       "downloaded_at": "2022-04-21 14:07:46.466776Z",
       "sha": "7ec5e75887483b1918e3c2ad3ed512c4d64f452e"
+    },
+    "user-RochelleKnight-confirmed-hospitalised-covid-19.csv": {
+      "id": "user/RochelleKnight/confirmed-hospitalised-covid-19/1f0d2526",
+      "url": "https://codelists.opensafely.org/codelist/user/RochelleKnight/confirmed-hospitalised-covid-19/1f0d2526/",
+      "downloaded_at": "2022-04-22 11:35:44.071847Z",
+      "sha": "7b472652a66eed89b0495a2cf43cf6e894451cb8"
     }
   }
 }

--- a/codelists/codelists.txt
+++ b/codelists/codelists.txt
@@ -162,3 +162,4 @@ bristol/hdl-cholesterol/64775990
 bristol/pe_i26/00398cbc
 bristol/pe_i260/672a1986
 bristol/pe_i269/4e1aa651
+user/RochelleKnight/confirmed-hospitalised-covid-19/1f0d2526

--- a/codelists/user-RochelleKnight-confirmed-hospitalised-covid-19.csv
+++ b/codelists/user-RochelleKnight-confirmed-hospitalised-covid-19.csv
@@ -1,0 +1,2 @@
+code,term
+U071,"COVID-19, virus identified"


### PR DESCRIPTION
Change hospitalised COVID diagnosis/COVID deaths diagnosis/COVID hospitalised phenotype to just use confirmed COVID-19 ICD10 code 