### PR TITLE
Add scripts to generate incidence plots

### DIFF
--- a/analysis/create_project_actions.R
+++ b/analysis/create_project_actions.R
@@ -215,6 +215,17 @@ actions_list <- splice(
     )
   ),
   
+  #comment("COVID Incidence Data"),
+  action(
+    name = "create_covid_incidence_data_both",
+    run = "r:latest analysis/descriptives/create_incidence_data.R both",
+    needs = list("preprocess_data_vaccinated","preprocess_data_electively_unvaccinated","stage1_data_cleaning_both"),
+    moderately_sensitive = list(
+      weekly = glue("output/review/figure-data/incidence/weekly_*.csv"),
+      cumulative = glue("output/review/figure-data/incidence/cum_*.csv")
+    ),
+  ),
+  
   #comment("Stage 1 - End date table"),
   action(
     name = "stage1_end_date_table_vaccinated",

--- a/analysis/descriptives/create_incidence_data.R
+++ b/analysis/descriptives/create_incidence_data.R
@@ -1,0 +1,160 @@
+## =============================================================================
+## Purpose:  Create data for incidence plots
+## 
+## Author:   Kurt Taylor
+##
+## Reviewer: 
+##
+## Date:     15th June 2022
+##
+## Data:     Post covid events study population
+##
+## Content: Create datasets of the incidence and cumulative incidence of COVID by week from the beginning of follow up to the end of follow-up for each cohort ready for plotting outside OS.
+## Output:  
+## =============================================================================
+
+library(ggplot2)
+library(incidence)
+library(readr)
+library(tidyverse)
+library(janitor)
+
+args <- commandArgs(trailingOnly=TRUE)
+
+if(length(args)==0){
+  # use for interactive testing
+  cohort_name <- "vaccinated"
+} else {
+  cohort_name <- args[[1]]
+}
+
+fs::dir_create(here::here("output", "not-for-review"))
+fs::dir_create(here::here("output", "review", "figure-data", "incidence"))
+
+incidence_output <- function(cohort_name, group) {
+  
+  # Read input dataset 
+  input_stage1 <- readr::read_rds(paste0("output/input_", cohort_name,"_stage1_", group,".rds"))
+  
+  ##------------------------------
+  # GENERATE DATA FOR WEEKLY INCIDENCE PLOTS --------------------------------------------------------------------
+  ##------------------------------
+  
+  # 1. Confirmed COVID cases
+  
+  # Use date of confirmed COVID
+  covid_cases <- input_stage1$exp_date_covid19_confirmed
+  
+  # Use incidence package generate an incidence object with weekly incidence 
+  incidence_object <- incidence(covid_cases, interval = "1 week: saturday")
+  # by sex
+  incidence_object_sex <- incidence(covid_cases, interval = "1 week: saturday", group =  input_stage1$cov_cat_sex)
+  # by age
+  # Define age groups (taken from table 1 code)
+  input_stage1$cov_cat_age_group <- ""
+  input_stage1$cov_cat_age_group <- ifelse(input_stage1$cov_num_age>=18 & input_stage1$cov_num_age<=29, "18-29", input_stage1$cov_cat_age_group)
+  input_stage1$cov_cat_age_group <- ifelse(input_stage1$cov_num_age>=30 & input_stage1$cov_num_age<=39, "30-39", input_stage1$cov_cat_age_group)
+  input_stage1$cov_cat_age_group <- ifelse(input_stage1$cov_num_age>=40 & input_stage1$cov_num_age<=49, "40-49", input_stage1$cov_cat_age_group)
+  input_stage1$cov_cat_age_group <- ifelse(input_stage1$cov_num_age>=50 & input_stage1$cov_num_age<=59, "50-59", input_stage1$cov_cat_age_group)
+  input_stage1$cov_cat_age_group <- ifelse(input_stage1$cov_num_age>=60 & input_stage1$cov_num_age<=69, "60-69", input_stage1$cov_cat_age_group)
+  input_stage1$cov_cat_age_group <- ifelse(input_stage1$cov_num_age>=70 & input_stage1$cov_num_age<=79, "70-79", input_stage1$cov_cat_age_group)
+  input_stage1$cov_cat_age_group <- ifelse(input_stage1$cov_num_age>=80 & input_stage1$cov_num_age<=89, "80-89", input_stage1$cov_cat_age_group)
+  input_stage1$cov_cat_age_group <- ifelse(input_stage1$cov_num_age>=90, "90+", input_stage1$cov_cat_age_group)
+  
+  incidence_object_age <- incidence(covid_cases, interval = "1 week: saturday", group =  input_stage1$cov_cat_age_group)
+  
+  # convert incidence object to a dataframe so that it can be exported from OpenSAFELY
+  incidence_object_df <- as.data.frame(incidence_object)
+  
+  incidence_object_age_df <- as.data.frame(incidence_object_age)
+  incidence_object_age_df <- clean_names(incidence_object_age_df)
+  colnames(incidence_object_age_df)<-gsub("x","Age",colnames(incidence_object_age_df))
+  incidence_object_age_df <- incidence_object_age_df %>% dplyr::rename(Age90_plus = Age90)
+  
+  incidence_object_sex_df <- as.data.frame(incidence_object_sex)
+
+  ##------------------------------
+  # GENERATE DATA FOR CUMULATIVE INCIDENCE PLOTS --------------------------------------------------------------------
+  ##------------------------------
+  
+  # Make COVID event variable yes no
+  
+  input_stage1 <- input_stage1 %>% 
+    mutate(covid_event = ifelse(is.na(exp_date_covid19_confirmed), 0, 1))
+  
+  # Prepare dataframes
+  
+  df <- input_stage1 %>%
+    dplyr::select(exp_date_covid19_confirmed, covid_event, cov_cat_sex, cov_cat_age_group) %>%
+    dplyr::rename(Sex = cov_cat_sex,
+                  Age_Group = cov_cat_age_group) %>%
+    mutate(All = "All")
+  
+  # ALL
+  
+  df_all <- df %>%
+    dplyr::select(exp_date_covid19_confirmed, covid_event, All) %>%
+    #removing NAs
+    .[complete.cases(df),] %>%
+    # Arrange by data
+    arrange(exp_date_covid19_confirmed) %>%
+    #wide format df with the count of each groups events at each time 
+    #(some dates have more than on event)(NA of dates mismatch, replace by 0)
+    pivot_wider(names_from = All,names_glue = "{All}", values_from = covid_event, values_fn = length, values_fill = 0) %>% 
+    #changing groups event per date to cumsum
+    mutate_at(-1,cumsum) %>%
+    # long format 
+    pivot_longer(cols = -1, names_to = "All", values_to = "Cumsum")
+  
+  # BY AGE 
+  
+  df_age <- df %>%
+    dplyr::select(exp_date_covid19_confirmed, covid_event, Age_Group) %>%
+    .[complete.cases(df),] %>%
+    arrange(exp_date_covid19_confirmed) %>%
+    pivot_wider(names_from = Age_Group,names_glue = "{Age_Group}", values_from = covid_event, values_fn = length, values_fill = 0) %>% 
+    mutate_at(-1,cumsum) %>%
+    pivot_longer(cols = -1, names_to = "Age_Group", values_to = "Cumsum")
+  
+  # BY SEX
+  
+  df_sex <- df %>%
+    dplyr::select(exp_date_covid19_confirmed, covid_event, Sex) %>%
+    .[complete.cases(df),] %>%
+    arrange(exp_date_covid19_confirmed) %>%
+    pivot_wider(names_from = Sex,names_glue = "{Sex}", values_from = covid_event, values_fn = length, values_fill = 0) %>% 
+    mutate_at(-1,cumsum) %>%
+    pivot_longer(cols = -1, names_to = "Sex", values_to = "Cumsum")
+  
+  ##------------------------------
+  # SAVE OUTPUTS  --------------------------------------------------------------------
+  ##------------------------------
+  
+  # WEEKLY
+  
+  write.csv(incidence_object_df, paste0("output/review/figure-data/incidence/weekly_incidence_all_", cohort_name,"_", group,".csv"), row.names = FALSE)
+  write.csv(incidence_object_age_df, paste0("output/review/figure-data/incidence/weekly_incidence_age_", cohort_name,"_", group,".csv"), row.names = FALSE)
+  write.csv(incidence_object_sex_df, paste0("output/review/figure-data/incidence/weekly_incidence_sex_", cohort_name,"_", group,".csv"), row.names = FALSE)
+  
+  # CUMULATIVE 
+  
+  write.csv(df_all, paste0("output/review/figure-data/incidence/cum_incidence_all_", cohort_name,"_", group,".csv"), row.names = FALSE)
+  write.csv(df_age, paste0("output/review/figure-data/incidence/cum_incidence_age_", cohort_name,"_", group,".csv"), row.names = FALSE)
+  write.csv(df_sex, paste0("output/review/figure-data/incidence/cum_incidence_sex_", cohort_name,"_", group,".csv"), row.names = FALSE)
+  
+}
+
+# Run function using specified commandArgs and active analyses for group
+
+active_analyses <- read_rds("lib/active_analyses.rds")
+active_analyses <- active_analyses %>% filter(active==TRUE)
+group <- unique(active_analyses$outcome_group)
+
+for(i in group){
+  if (cohort_name == "both") {
+    incidence_output("electively_unvaccinated", i)
+    incidence_output("vaccinated", i)
+  } else{
+    incidence_output(cohort_name, i)
+  }
+}

--- a/analysis/descriptives/create_incidence_data.R
+++ b/analysis/descriptives/create_incidence_data.R
@@ -31,10 +31,10 @@ if(length(args)==0){
 fs::dir_create(here::here("output", "not-for-review"))
 fs::dir_create(here::here("output", "review", "figure-data", "incidence"))
 
-incidence_output <- function(cohort_name, group) {
+incidence_output <- function(cohort_name) {
   
   # Read input dataset 
-  input_stage1 <- readr::read_rds(paste0("output/input_", cohort_name,"_stage1_", group,".rds"))
+  input_stage1 <- readr::read_rds(paste0("output/input_", cohort_name,"_stage1.rds"))
   
   ##------------------------------
   # GENERATE DATA FOR WEEKLY INCIDENCE PLOTS --------------------------------------------------------------------
@@ -132,29 +132,36 @@ incidence_output <- function(cohort_name, group) {
   
   # WEEKLY
   
-  write.csv(incidence_object_df, paste0("output/review/figure-data/incidence/weekly_incidence_all_", cohort_name,"_", group,".csv"), row.names = FALSE)
-  write.csv(incidence_object_age_df, paste0("output/review/figure-data/incidence/weekly_incidence_age_", cohort_name,"_", group,".csv"), row.names = FALSE)
-  write.csv(incidence_object_sex_df, paste0("output/review/figure-data/incidence/weekly_incidence_sex_", cohort_name,"_", group,".csv"), row.names = FALSE)
+  write.csv(incidence_object_df, paste0("output/review/figure-data/incidence/weekly_incidence_all_", cohort_name,".csv"), row.names = FALSE)
+  write.csv(incidence_object_age_df, paste0("output/review/figure-data/incidence/weekly_incidence_age_", cohort_name,".csv"), row.names = FALSE)
+  write.csv(incidence_object_sex_df, paste0("output/review/figure-data/incidence/weekly_incidence_sex_", cohort_name,".csv"), row.names = FALSE)
   
   # CUMULATIVE 
   
-  write.csv(df_all, paste0("output/review/figure-data/incidence/cum_incidence_all_", cohort_name,"_", group,".csv"), row.names = FALSE)
-  write.csv(df_age, paste0("output/review/figure-data/incidence/cum_incidence_age_", cohort_name,"_", group,".csv"), row.names = FALSE)
-  write.csv(df_sex, paste0("output/review/figure-data/incidence/cum_incidence_sex_", cohort_name,"_", group,".csv"), row.names = FALSE)
+  write.csv(df_all, paste0("output/review/figure-data/incidence/cum_incidence_all_", cohort_name,".csv"), row.names = FALSE)
+  write.csv(df_age, paste0("output/review/figure-data/incidence/cum_incidence_age_", cohort_name,".csv"), row.names = FALSE)
+  write.csv(df_sex, paste0("output/review/figure-data/incidence/cum_incidence_sex_", cohort_name,".csv"), row.names = FALSE)
   
 }
 
 # Run function using specified commandArgs and active analyses for group
 
-active_analyses <- read_rds("lib/active_analyses.rds")
-active_analyses <- active_analyses %>% filter(active==TRUE)
-group <- unique(active_analyses$outcome_group)
+# active_analyses <- read_rds("lib/active_analyses.rds")
+# active_analyses <- active_analyses %>% filter(active==TRUE)
+# group <- unique(active_analyses$outcome_group)
 
-for(i in group){
   if (cohort_name == "both") {
-    incidence_output("electively_unvaccinated", i)
-    incidence_output("vaccinated", i)
+    incidence_output("electively_unvaccinated")
+    incidence_output("vaccinated")
   } else{
-    incidence_output(cohort_name, i)
+    incidence_output(cohort_name)
   }
-}
+
+# for(i in group){
+#   if (cohort_name == "both") {
+#     incidence_output("electively_unvaccinated", i)
+#     incidence_output("vaccinated", i)
+#   } else{
+#     incidence_output(cohort_name, i)
+#   }
+# }

--- a/analysis/figures/create_incidence_plots.R
+++ b/analysis/figures/create_incidence_plots.R
@@ -1,0 +1,171 @@
+## =============================================================================
+## Purpose:  Create plots from incident data (OUTSIDE OF OPENSAFELY)
+## 
+## Author:   Kurt Taylor
+##
+## Reviewer: 
+##
+## Date:     15th June 2022
+##
+## Data:     Post covid events study population
+##
+## Content: Create plots of the incidence and cumulative incidence of COVID by week from the beginning of follow up to the end of follow-up for each cohort.
+## Output:  
+## =============================================================================
+
+library(outbreaks)
+library(ggplot2)
+library(incidence)
+library(readr)
+library(tidyverse)
+library(cowplot)
+library(scales)
+
+cov_incidence_plot <- function(cohort_name, group) {
+  
+  ##------------------------------
+  # WEEKLY INCIDENCE ---------------------------------------------------
+  ##------------------------------
+  
+  # Read in the files outputted from OS
+  
+  weekly_all <- read.csv(paste0("output/review/figure-data/incidence/weekly_incidence_all_", cohort_name,"_", group,".csv"))
+  weekly_age <- read.csv(paste0("output/review/figure-data/incidence/weekly_incidence_age_", cohort_name,"_", group,".csv"))
+  weekly_sex <- read.csv(paste0("output/review/figure-data/incidence/weekly_incidence_sex_", cohort_name,"_", group,".csv"))
+  
+  # Turn data frames back into incidence objects 
+  
+  weekly_all_inc <- incidence(rep(weekly_all$dates, weekly_all$counts), interval = "1 saturday weeks")
+  
+  weekly_age_inc <- incidence(c(rep(weekly_age$dates, weekly_age$Age18_29),rep(weekly_age$dates, weekly_age$Age30_39), 
+                                rep(weekly_age$dates, weekly_age$Age40_49),rep(weekly_age$dates, weekly_age$Age50_59), 
+                                rep(weekly_age$dates, weekly_age$Age60_69),rep(weekly_age$dates, weekly_age$Age70_79), 
+                                rep(weekly_age$dates, weekly_age$Age80_89),rep(weekly_age$dates, weekly_age$Age90_plus)),
+                              groups = c(rep("Age18_29",sum(weekly_age$Age18_29)), rep("Age30_39",sum(weekly_age$Age30_39)),
+                                         rep("Age40_49",sum(weekly_age$Age40_49)), rep("Age50_59",sum(weekly_age$Age50_59)),
+                                         rep("Age_60_69",sum(weekly_age$Age60_69)), rep("Age70_79",sum(weekly_age$Age70_79)),
+                                         rep("Age80_89",sum(weekly_age$Age80_89)), rep("Age90_plus",sum(weekly_age$Age90_plus))),
+                              interval = "1 saturday weeks")
+  
+  weekly_sex_inc <- incidence(c(rep(weekly_sex$dates, weekly_sex$Female),rep(weekly_sex$dates, weekly_sex$Male)),
+                             groups = c(rep("Female",sum(weekly_sex$Female)), rep("Male",sum(weekly_sex$Male))),
+                             interval = "1 saturday weeks")
+  
+  weekly_all_plot <- plot(weekly_all_inc, labels_week = FALSE) + scale_x_date(labels = date_format("%b %Y"))
+  weekly_age_plot <- plot(weekly_age_inc, labels_week = FALSE) + scale_x_date(labels = date_format("%b %Y"))
+  weekly_sex_plot <- plot(weekly_sex_inc, labels_week = FALSE) + scale_x_date(labels = date_format("%b %Y"))
+  
+  ##------------------------------
+  # CUMULATIVE INCIDENCE ---------
+  ##------------------------------
+  
+  # Read in the files outputted from OS and change date var to date class
+  
+  cum_all <- read.csv(paste0("output/review/figure-data/incidence/cum_incidence_all_", cohort_name,"_", group,".csv"))
+  cum_all$exp_date_covid19_confirmed <- as.Date(cum_all$exp_date_covid19_confirmed)
+  cum_age <- read.csv(paste0("output/review/figure-data/incidence/cum_incidence_age_", cohort_name,"_", group,".csv"))
+  cum_age$exp_date_covid19_confirmed <- as.Date(cum_age$exp_date_covid19_confirmed)
+  cum_sex <- read.csv(paste0("output/review/figure-data/incidence/cum_incidence_sex_", cohort_name,"_", group,".csv"))
+  cum_sex$exp_date_covid19_confirmed <- as.Date(cum_sex$exp_date_covid19_confirmed)
+  
+  # Plotting
+  
+  cumulative_all_plot <- cum_all %>% ggplot() + 
+    geom_line(aes(x = exp_date_covid19_confirmed, y = Cumsum, linetype = All)) + 
+    labs(y = "Cumulative cases of COVID-19", x = NULL)
+  
+  cumulative_age_plot <- cum_age %>% ggplot() + 
+    geom_line(aes(x = exp_date_covid19_confirmed, y = Cumsum, linetype = Age_Group, col = Age_Group)) + 
+    labs(y = "Cumulative cases of COVID-19", x = NULL)
+  
+  cumulative_sex_plot <- cum_sex %>% ggplot() + 
+    geom_line(aes(x = exp_date_covid19_confirmed, y = Cumsum, linetype = Sex)) + 
+    labs(y = "Cumulative cases of COVID-19", x = NULL)
+  
+  ##------------------------------
+  # COMBINE PLOTS AND SAVE -------
+  ##------------------------------
+  
+  # CREATE PLOT TITLES
+  
+  title_theme <- ggdraw() +
+    draw_label("COVID-19 incidence without stratification", 
+               x = 0, hjust = 0, size = 22, fontface = "bold")
+  
+  title_theme_age <- ggdraw() +
+    draw_label("COVID-19 incidence stratified by age groups", 
+               x = 0, hjust = 0, size = 22, fontface = "bold")
+  
+  title_theme_sex <- ggdraw() +
+    draw_label("COVID-19 incidence stratified by sex", 
+               x = 0, hjust = 0, size = 22, fontface = "bold")
+  
+  # PLOT WITHOUT STRATIFICATION
+  
+  all_plots <- plot_grid(weekly_all_plot, cumulative_all_plot, ncol=2, nrow = 1,
+            labels = c("A: Weekly incidence of COVID-19 cases", "B: Cumulative incidence of COVID-19 cases"),
+            label_x = -0.2,
+            hjust = -0.5, scale = 0.93)
+  png(paste0(local_file_output,"incidence_plot_", cohort_name, "_", group, ".png"),
+      width = 15, height = 8, units = "in", res = 400)
+  plot_grid(title_theme, all_plots, ncol = 1, rel_heights = c(0.1, 1))
+  print(all_plots)
+  dev.off()
+  
+  # PLOT STRATIFYING BY AGE
+  
+  age_plots <- plot_grid(weekly_age_plot, cumulative_age_plot, ncol=2, nrow = 1,
+                         labels = c("A: Weekly incidence of COVID-19 cases", "B: Cumulative incidence of COVID-19 cases"),
+                         label_x = -0.2,
+                         hjust = -0.5, scale = 0.93)
+  png(paste0(local_file_output,"incidence_plot_by_age_", cohort_name, "_", group, ".png"),
+      width = 15, height = 8, units = "in", res = 400)
+  plot_grid(title_theme_age, age_plots, ncol = 1, rel_heights = c(0.1, 1))
+  print(age_plots)
+  dev.off()
+  
+  # PLOT STRATIFYING BY SEX
+  
+  sex_plots <- plot_grid(weekly_sex_plot, cumulative_sex_plot, ncol=2, nrow = 1,
+                         labels = c("A: Weekly incidence of COVID-19 cases", "B: Cumulative incidence of COVID-19 cases"),
+                         label_x = -0.2,
+                         hjust = -0.5, scale = 0.93)
+  png(paste0(local_file_output,"incidence_plot_by_sex_", cohort_name, "_", group, ".png"),
+      width = 15, height = 8, units = "in", res = 400)
+  plot_grid(title_theme_sex, sex_plots, ncol = 1, rel_heights = c(0.1, 1))
+  print(sex_plots)
+  dev.off()
+  
+}
+
+##--------------------
+# RUN FUNCTION -------
+##--------------------
+
+# SPECIFICATIONS 
+
+# change cohort name to "vaccinated", "unvaccinated" or "both"
+
+cohort_name <- "vaccinated"
+
+# use active analyses if you have more than one more "outcome group" to loop over
+# active_analyses <- read_rds("lib/active_analyses.rds")
+# active_analyses <- active_analyses %>% filter(active==TRUE)
+# group <- unique(active_analyses$outcome_group)
+
+# or manually change outcome group here: 
+group <- "diabetes"
+
+# change file path to where you want to save the figures
+local_file_output <- "/Users/kt17109/OneDrive - University of Bristol/Documents - grp-EHR/Projects/post-covid-diabetes/incidence-plots/"
+
+for(i in group){
+  if (cohort_name == "both") {
+    cov_incidence_plot("electively_unvaccinated", i)
+    cov_incidence_plot("vaccinated", i)
+  } else{
+    cov_incidence_plot(cohort_name, i)
+  }
+}
+
+### END

--- a/analysis/figures/create_incidence_plots.R
+++ b/analysis/figures/create_incidence_plots.R
@@ -21,7 +21,7 @@ library(tidyverse)
 library(cowplot)
 library(scales)
 
-cov_incidence_plot <- function(cohort_name, group) {
+cov_incidence_plot <- function(cohort_name) {
   
   ##------------------------------
   # WEEKLY INCIDENCE ---------------------------------------------------
@@ -29,9 +29,9 @@ cov_incidence_plot <- function(cohort_name, group) {
   
   # Read in the files outputted from OS
   
-  weekly_all <- read.csv(paste0("output/review/figure-data/incidence/weekly_incidence_all_", cohort_name,"_", group,".csv"))
-  weekly_age <- read.csv(paste0("output/review/figure-data/incidence/weekly_incidence_age_", cohort_name,"_", group,".csv"))
-  weekly_sex <- read.csv(paste0("output/review/figure-data/incidence/weekly_incidence_sex_", cohort_name,"_", group,".csv"))
+  weekly_all <- read.csv(paste0("output/review/figure-data/incidence/weekly_incidence_all_", cohort_name,".csv"))
+  weekly_age <- read.csv(paste0("output/review/figure-data/incidence/weekly_incidence_age_", cohort_name,".csv"))
+  weekly_sex <- read.csv(paste0("output/review/figure-data/incidence/weekly_incidence_sex_", cohort_name,".csv"))
   
   # Turn data frames back into incidence objects 
   
@@ -61,11 +61,11 @@ cov_incidence_plot <- function(cohort_name, group) {
   
   # Read in the files outputted from OS and change date var to date class
   
-  cum_all <- read.csv(paste0("output/review/figure-data/incidence/cum_incidence_all_", cohort_name,"_", group,".csv"))
+  cum_all <- read.csv(paste0("output/review/figure-data/incidence/cum_incidence_all_", cohort_name,".csv"))
   cum_all$exp_date_covid19_confirmed <- as.Date(cum_all$exp_date_covid19_confirmed)
-  cum_age <- read.csv(paste0("output/review/figure-data/incidence/cum_incidence_age_", cohort_name,"_", group,".csv"))
+  cum_age <- read.csv(paste0("output/review/figure-data/incidence/cum_incidence_age_", cohort_name,".csv"))
   cum_age$exp_date_covid19_confirmed <- as.Date(cum_age$exp_date_covid19_confirmed)
-  cum_sex <- read.csv(paste0("output/review/figure-data/incidence/cum_incidence_sex_", cohort_name,"_", group,".csv"))
+  cum_sex <- read.csv(paste0("output/review/figure-data/incidence/cum_incidence_sex_", cohort_name,".csv"))
   cum_sex$exp_date_covid19_confirmed <- as.Date(cum_sex$exp_date_covid19_confirmed)
   
   # Plotting
@@ -159,13 +159,20 @@ group <- "diabetes"
 # change file path to where you want to save the figures
 local_file_output <- "/Users/kt17109/OneDrive - University of Bristol/Documents - grp-EHR/Projects/post-covid-diabetes/incidence-plots/"
 
-for(i in group){
   if (cohort_name == "both") {
-    cov_incidence_plot("electively_unvaccinated", i)
-    cov_incidence_plot("vaccinated", i)
+    cov_incidence_plot("electively_unvaccinated")
+    cov_incidence_plot("vaccinated")
   } else{
-    cov_incidence_plot(cohort_name, i)
+    cov_incidence_plot(cohort_name)
   }
-}
+
+# for(i in group){
+#   if (cohort_name == "both") {
+#     cov_incidence_plot("electively_unvaccinated", i)
+#     cov_incidence_plot("vaccinated", i)
+#   } else{
+#     cov_incidence_plot(cohort_name, i)
+#   }
+# }
 
 ### END

--- a/project.yaml
+++ b/project.yaml
@@ -89,6 +89,17 @@ actions:
       highly_sensitive:
         cohort: output/input_*_stage1.rds
 
+  create_covid_incidence_data_both:
+    run: r:latest analysis/descriptives/create_incidence_data.R both
+    needs:
+    - preprocess_data_vaccinated
+    - preprocess_data_electively_unvaccinated
+    - stage1_data_cleaning_both
+    outputs:
+      moderately_sensitive:
+        weekly: output/review/figure-data/incidence/weekly_*.csv
+        cumulative: output/review/figure-data/incidence/cum_*.csv
+
   stage1_end_date_table_vaccinated:
     run: r:latest analysis/preprocess/create_follow_up_end_date.R vaccinated
     needs:


### PR DESCRIPTION
2 x scripts have been added to create [COVID incidence plots as requested by Jonathan](https://github.com/opensafely/post-covid-vaccinated/issues/213). One of these scripts is called as an action in the yaml and the other script is to be ran locally once the output from the first script has been released. I haven't included disclosure control as it is weekly data and should be quite high numbers I would imagine. If I am wrong, can someone please add some disclosure control. 

Please feel free to edit/play around with the figures. I didn't want to spend too much time making them look beautiful as Jonathan will probably request changes either way 😄 

Note: This script will need to be updated with "outcome groups" once the diabetes analysis is merged (I originally generated these scripts as part of the same PR where I generated outcome groups for diabetes analyses). See [here](https://github.com/opensafely/post-covid-vaccinated/commit/7dbb70c130360477978190eff261f54eda54ba2b).