### PR TITLE
test update sampling for specific outcomes

### DIFF
--- a/analysis/model/04_01_(b)_cox_format_survival_data.R
+++ b/analysis/model/04_01_(b)_cox_format_survival_data.R
@@ -33,6 +33,14 @@ fit_get_data_surv <- function(event,subgroup, stratify_by_subgroup, stratify_by,
     controls_per_case <- ceiling((5000000-nrow(cases))/nrow(cases))
   }
   
+  if(event_name == "pe" & cohort == "vaccinated" & subgroup == "covid_pheno_hospitalised"){
+    controls_per_case <- ceiling((4000000-nrow(cases))/nrow(cases))
+  }
+  
+  if(event_name == "vte" & cohort == "electively_unvaccinated" & subgroup != "main"){
+    controls_per_case <- ceiling((5000000-nrow(cases))/nrow(cases))
+  }
+  
   print(paste0("Number of controls per case: ", controls_per_case))
   
   if(startsWith(subgroup,"covid_pheno_")){


### PR DESCRIPTION
- For vaccinated PE hospitalised analysis set sampling back to 4 million
- For VTE electively unvaccinated do not sample for subgroups