### PR TITLE
Age sex obesity in stata

### DIFF
--- a/analysis/cox_model.do
+++ b/analysis/cox_model.do
@@ -206,7 +206,7 @@ bysort days: summarize(follow_up), detail
 
 stcox days0_28 days28_197 i.sex age_spline1 age_spline2, strata(region) vce(r)
 est store min, title(Age_Sex)
-stcox days0_28 days28_197 i.sex age_spline1 age_spline2, i.cov_bin_obesity vce(r)
+stcox days0_28 days28_197 i.sex age_spline1 age_spline2 i.cov_bin_obesity, vce(r)
 est store age_sex_obesity, title(Age_Sex_Obesity)
 stcox days0_28 days28_197 i.sex age_spline1 age_spline2 i.cov_cat_ethnicity i.cov_cat_deprivation i.cov_cat_smoking_status cov_num_consulation_rate cov_bin_*, strata(region) vce(r)
 est store max, title(Maximal)

--- a/analysis/cox_model.do
+++ b/analysis/cox_model.do
@@ -207,7 +207,7 @@ bysort days: summarize(follow_up), detail
 stcox days0_28 days28_197 i.sex age_spline1 age_spline2, strata(region) vce(r)
 est store min, title(Age_Sex)
 stcox days0_28 days28_197 i.sex age_spline1 age_spline2, i.cov_bin_obesity vce(r)
-est store age_sex_obesity, title(Age_Sex_obesity)
+est store age_sex_obesity, title(Age_Sex_Obesity)
 stcox days0_28 days28_197 i.sex age_spline1 age_spline2 i.cov_cat_ethnicity i.cov_cat_deprivation i.cov_cat_smoking_status cov_num_consulation_rate cov_bin_*, strata(region) vce(r)
 est store max, title(Maximal)
 

--- a/analysis/cox_model.do
+++ b/analysis/cox_model.do
@@ -206,6 +206,8 @@ bysort days: summarize(follow_up), detail
 
 stcox days0_28 days28_197 i.sex age_spline1 age_spline2, strata(region) vce(r)
 est store min, title(Age_Sex)
+stcox days0_28 days28_197 i.sex age_spline1 age_spline2, i.cov_bin_obesity vce(r)
+est store age_sex_obesity, title(Age_Sex_obesity)
 stcox days0_28 days28_197 i.sex age_spline1 age_spline2 i.cov_cat_ethnicity i.cov_cat_deprivation i.cov_cat_smoking_status cov_num_consulation_rate cov_bin_*, strata(region) vce(r)
 est store max, title(Maximal)
 

--- a/analysis/cox_model_day0.do
+++ b/analysis/cox_model_day0.do
@@ -211,7 +211,7 @@ bysort days: summarize(follow_up), detail
 stcox days0_1 days1_28 days28_197 i.sex age_spline1 age_spline2, strata(region) vce(r)
 est store min, title(Age_Sex)
 stcox days0_1 days1_28 days28_197 i.sex age_spline1 age_spline2, i.cov_bin_obesity vce(r)
-est store age_sex_obesity, title(Age_Sex_obesity)
+est store age_sex_obesity, title(Age_Sex_Obesity)
 stcox days0_1 days1_28 days28_197 i.sex age_spline1 age_spline2 i.cov_cat_ethnicity i.cov_cat_deprivation i.cov_cat_smoking_status cov_num_consulation_rate cov_bin_*, strata(region) vce(r)
 est store max, title(Maximal)
 

--- a/analysis/cox_model_day0.do
+++ b/analysis/cox_model_day0.do
@@ -210,7 +210,7 @@ bysort days: summarize(follow_up), detail
 
 stcox days0_1 days1_28 days28_197 i.sex age_spline1 age_spline2, strata(region) vce(r)
 est store min, title(Age_Sex)
-stcox days0_1 days1_28 days28_197 i.sex age_spline1 age_spline2, i.cov_bin_obesity vce(r)
+stcox days0_1 days1_28 days28_197 i.sex age_spline1 age_spline2 i.cov_bin_obesity, vce(r)
 est store age_sex_obesity, title(Age_Sex_Obesity)
 stcox days0_1 days1_28 days28_197 i.sex age_spline1 age_spline2 i.cov_cat_ethnicity i.cov_cat_deprivation i.cov_cat_smoking_status cov_num_consulation_rate cov_bin_*, strata(region) vce(r)
 est store max, title(Maximal)

--- a/analysis/cox_model_day0.do
+++ b/analysis/cox_model_day0.do
@@ -210,6 +210,8 @@ bysort days: summarize(follow_up), detail
 
 stcox days0_1 days1_28 days28_197 i.sex age_spline1 age_spline2, strata(region) vce(r)
 est store min, title(Age_Sex)
+stcox days0_1 days1_28 days28_197 i.sex age_spline1 age_spline2, i.cov_bin_obesity vce(r)
+est store age_sex_obesity, title(Age_Sex_obesity)
 stcox days0_1 days1_28 days28_197 i.sex age_spline1 age_spline2 i.cov_cat_ethnicity i.cov_cat_deprivation i.cov_cat_smoking_status cov_num_consulation_rate cov_bin_*, strata(region) vce(r)
 est store max, title(Maximal)
 


### PR DESCRIPTION
Add age/sex/obesity models in stata - these only need to be run for ATE/VTE but thought it might be easiest to just add it in to the script to run for all outcomes? Would be good if a stata user could give these changes a look over to make sure nothing else is needed